### PR TITLE
[BE] 엔티티가 DB에 저장될때 생성, 수정 시간이 자동으로 저장되게 한다. (#61)

### DIFF
--- a/backend/src/main/java/com/darass/darass/DarassApplication.java
+++ b/backend/src/main/java/com/darass/darass/DarassApplication.java
@@ -2,7 +2,6 @@ package com.darass.darass;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class DarassApplication {

--- a/backend/src/main/java/com/darass/darass/DarassApplication.java
+++ b/backend/src/main/java/com/darass/darass/DarassApplication.java
@@ -2,6 +2,7 @@ package com.darass.darass;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class DarassApplication {

--- a/backend/src/main/java/com/darass/darass/auth/oauth/controller/RequiredLoginArgumentResolver.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/controller/RequiredLoginArgumentResolver.java
@@ -16,6 +16,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
 public class RequiredLoginArgumentResolver implements HandlerMethodArgumentResolver {
+
     private final OAuthService oAuthService;
 
     @Override

--- a/backend/src/main/java/com/darass/darass/auth/oauth/domain/AuthenticationPrincipal.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/domain/AuthenticationPrincipal.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthenticationPrincipal {
+
 }

--- a/backend/src/main/java/com/darass/darass/comment/controller/dto/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/darass/darass/comment/controller/dto/CommentUpdateRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CommentUpdateRequest {
+
     private String content;
 
 }

--- a/backend/src/main/java/com/darass/darass/comment/domain/Comment.java
+++ b/backend/src/main/java/com/darass/darass/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.darass.darass.comment.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import com.darass.darass.project.domain.Project;
 import com.darass.darass.user.domain.User;
 import javax.persistence.Entity;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/darass/darass/common/EnableJpaAuditingConfiguration.java
+++ b/backend/src/main/java/com/darass/darass/common/EnableJpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.darass.darass.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class EnableJpaAuditingConfiguration {
+
+}

--- a/backend/src/main/java/com/darass/darass/common/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/darass/darass/common/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.darass.darass.common.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/backend/src/main/java/com/darass/darass/exception/controller/AdviceController.java
+++ b/backend/src/main/java/com/darass/darass/exception/controller/AdviceController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class AdviceController {
 
-    @ExceptionHandler({ ConstraintViolationException.class, BadRequestException.class })
+    @ExceptionHandler({ConstraintViolationException.class, BadRequestException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handle(ConstraintViolationException e) {
         return new ExceptionResponse(e.getMessage(), HttpStatus.BAD_REQUEST.value());

--- a/backend/src/main/java/com/darass/darass/exception/dto/ExceptionResponse.java
+++ b/backend/src/main/java/com/darass/darass/exception/dto/ExceptionResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class ExceptionResponse {
+
     private String message;
     private Integer code;
 }

--- a/backend/src/main/java/com/darass/darass/project/domain/Project.java
+++ b/backend/src/main/java/com/darass/darass/project/domain/Project.java
@@ -1,5 +1,6 @@
 package com.darass.darass.project.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import com.darass.darass.user.domain.User;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class Project {
+public class Project extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/darass/darass/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/darass/darass/project/repository/ProjectRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
     Project findBySecretKey(String projectSecretKey);
 
     List<ProjectResponse> findByUserId(Long userId);

--- a/backend/src/main/java/com/darass/darass/project/service/ProjectService.java
+++ b/backend/src/main/java/com/darass/darass/project/service/ProjectService.java
@@ -20,10 +20,10 @@ public class ProjectService {
 
     public ProjectResponse save(ProjectCreateRequest projectRequest, User user) {
         Project project = Project.builder()
-                .name(projectRequest.getName())
-                .secretKey(projectRequest.getSecretKey())
-                .user(user)
-                .build();
+            .name(projectRequest.getName())
+            .secretKey(projectRequest.getSecretKey())
+            .user(user)
+            .build();
         projects.save(project);
         return ProjectResponse.of(project);
     }
@@ -34,7 +34,7 @@ public class ProjectService {
 
     public ProjectResponse findByIdAndUserId(Long projectId, Long userId) {
         Project project = projects.findByIdAndUserId(projectId, userId)
-                .orElseThrow(() -> ExceptionWithMessageAndCode.NOT_FOUND_PROJECT.getException());
+            .orElseThrow(() -> ExceptionWithMessageAndCode.NOT_FOUND_PROJECT.getException());
         return ProjectResponse.of(project);
     }
 

--- a/backend/src/main/java/com/darass/darass/user/domain/User.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/User.java
@@ -26,12 +26,12 @@ public abstract class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickName;
 
-    @Column(name="user_type", insertable = false, updatable = false)
+    @Column(name = "user_type", insertable = false, updatable = false)
     private String userType;
-
-    public abstract boolean isLoginUser();
 
     public User(String nickName) {
         this.nickName = nickName;
     }
+
+    public abstract boolean isLoginUser();
 }

--- a/backend/src/main/java/com/darass/darass/user/domain/User.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.darass.darass.user.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @DiscriminatorColumn(name = "user_type")
 @Getter
 @NoArgsConstructor
-public abstract class User {
+public abstract class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/test/java/com/darass/darass/common/domain/BaseTimeEntityTest.java
+++ b/backend/src/test/java/com/darass/darass/common/domain/BaseTimeEntityTest.java
@@ -1,0 +1,44 @@
+package com.darass.darass.common.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.darass.darass.user.domain.OAuthPlatform;
+import com.darass.darass.user.domain.SocialLoginUser;
+import com.darass.darass.user.repository.SocialLoginUserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class BaseTimeEntityTest {
+
+    @Autowired
+    SocialLoginUserRepository socialLoginUserRepository;
+
+    @DisplayName("BaseTimeEntity을 상속한 Entity는 save될 때 생성시간과, 수정시간이 자동으로 저장된다.")
+    @Test
+    public void saveCreatedDateAndModifiedDate() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        socialLoginUserRepository.save(SocialLoginUser.builder()
+            .nickName("병욱")
+            .email("jujubebat@kakao.com")
+            .oauthId("241323123")
+            .oauthPlatform(OAuthPlatform.KAKAO)
+            .build());
+
+        //when
+        List<SocialLoginUser> socialLoginUsers = socialLoginUserRepository.findAll();
+
+        //then
+        SocialLoginUser socialLoginUser = socialLoginUsers.get(0);
+        assertThat(socialLoginUser.getCreatedDate()).isAfter(now);
+        assertThat(socialLoginUser.getModifiedDate()).isAfter(now);
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- Entity 저장시 생성, 수정 시간이 자동으로 저장되는 기능 구현 
- `BaseTimeEntity` 클래스를 상속하는 Entity들에게 적용됨 

## 발생했던 이슈  및 해결 방법
`BaseTimeEntity `기능을 활성화하기 위해 @EnableJpaAuditing 어노테이션을 `DarassApplication.class`(부트 스트랩 클래스라고도 불리움)에 붙였었음

```java
@EnableJpaAuditing 
@SpringBootApplication
public class DarassApplication {

    public static void main(String[] args) {
        SpringApplication.run(DarassApplication.class, args);
    }

}
```

그러자 `@RestClientTest`를 사용하는 `UserInfoProviderTest` 클래스의 테스트가 모두 깨지기 시작함
`UserInfoProviderTest` 클래스는 아래와 같음 

```java
@DisplayName("UserInfoProvider 클래스")
@RestClientTest(UserInfoProvider.class)
class UserInfoProviderTest {

    @Autowired
    private UserInfoProvider userInfoProvider;

    @Autowired
    private MockRestServiceServer mockServer;

    @Autowired
    private ObjectMapper objectMapper;

```

#### 에러 원인
- 테스트 코드 수행시 부트 스트랩 클래스 즉, `DarassApplication` 클래스가 항상 로딩됨 그래서 `@EnableJpaAuditing` 도 활성화됨
- `@RestClientTest` 을 사용하는 `UserInfoProviderTest` 클래스는 Jpa 관련 빈들을 로딩하지 않음. 하지만 그럼에도 불구하고 `@EnableJpaAuditing`이 활성화 되니까 에러가나는 것이었다. 

#### 해결 방법
- `@EnableJpaAuditing` 을 `DarassApplication`클래스 위에 붙이지 않고 별도의 configration 클래스를 생성하여 붙여줘서 해결 

#### 참고 
- https://sup2is.tistory.com/107
- https://stackoverflow.com/questions/60606861/spring-boot-jpa-metamodel-must-not-be-empty-when-trying-to-run-junit-integrat