### PR TITLE
[BE] Jacoco 플러그인을 추가한다. (#66)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,11 +4,14 @@ plugins {
     id 'java'
     // RestDocs 관련
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
+    // jacoco
+    id 'jacoco'
 }
 
 group = 'com.darass'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
+targetCompatibility = '11'
 
 configurations {
     compileOnly {
@@ -49,6 +52,10 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    jacoco {
+        destinationFile = file("$buildDir/jacoco/jacoco.exec")
+    }
+    finalizedBy 'jacocoTestReport'
 }
 
 ext {
@@ -72,4 +79,89 @@ asciidoctor.doLast {
 
 build {
     dependsOn asciidoctor
+}
+
+jacoco {
+// jaCoCo 버전
+    toolVersion = '0.8.5'
+
+    // 테스트 결과 리포트 파일 저장 경로
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestReport {
+    reports {
+        // 원하는 리포트를 켜고 끌 수 있다.
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+
+        //  각 리포트 타입 마다 리포트 저장 경로를 설정할 수 있다.
+        html.destination file("$buildDir/jacocoHtml")
+        //  xml.destination file("$buildDir/jacoco.xml")
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            // 'element'가 없으면 프로젝트의 전체 파일을 합친 값을 기준으로 한다.
+            // 위의 리포트에서 'Total'로 표시된 부분이다.
+            limit {
+                // 'counter'를 지정하지 않으면 default는 'INSTRUCTION'
+                // 'value'를 지정하지 않으면 default는 'COVEREDRATIO'
+                minimum = 0.30
+            }
+        }
+
+        // 여러 룰을 생성할 수 있다.
+        rule {
+            // 룰을 간단히 켜고 끌 수 있다.
+            enabled = true
+
+            // 룰을 체크할 단위는 클래스 단위
+            element = 'CLASS'
+
+            // 브랜치 커버리지를 최소한 90% 만족시켜야 한다.
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // 라인 커버리지를 최소한 80% 만족시켜야 한다.
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // 빈 줄을 제외한 코드의 라인수를 최대 200라인으로 제한한다.
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 200
+            }
+            // 커버리지 체크를 제외할 클래스들
+            excludes = [
+                    // '*.test.*',
+                    '*.Kotlin*'
+            ]
+
+        }
+    }
+}
+
+
+task testCoverage(type: Test) {
+    group 'verification'
+    description 'Runs the unit tests with coverage'
+
+    dependsOn(':test',
+            ':jacocoTestReport',
+            ':jacocoTestCoverageVerification')
+
+    tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+    tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
 }

--- a/backend/src/main/java/com/darass/darass/auth/oauth/controller/RequiredLoginArgumentResolver.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/controller/RequiredLoginArgumentResolver.java
@@ -16,6 +16,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
 public class RequiredLoginArgumentResolver implements HandlerMethodArgumentResolver {
+
     private final OAuthService oAuthService;
 
     @Override

--- a/backend/src/main/java/com/darass/darass/auth/oauth/domain/AuthenticationPrincipal.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/domain/AuthenticationPrincipal.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthenticationPrincipal {
+
 }

--- a/backend/src/main/java/com/darass/darass/comment/controller/dto/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/darass/darass/comment/controller/dto/CommentUpdateRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CommentUpdateRequest {
+
     private String content;
 
 }

--- a/backend/src/main/java/com/darass/darass/comment/domain/Comment.java
+++ b/backend/src/main/java/com/darass/darass/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.darass.darass.comment.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import com.darass.darass.project.domain.Project;
 import com.darass.darass.user.domain.User;
 import javax.persistence.Entity;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/darass/darass/common/EnableJpaAuditingConfiguration.java
+++ b/backend/src/main/java/com/darass/darass/common/EnableJpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.darass.darass.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class EnableJpaAuditingConfiguration {
+
+}

--- a/backend/src/main/java/com/darass/darass/common/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/darass/darass/common/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.darass.darass.common.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/backend/src/main/java/com/darass/darass/exception/controller/AdviceController.java
+++ b/backend/src/main/java/com/darass/darass/exception/controller/AdviceController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class AdviceController {
 
-    @ExceptionHandler({ ConstraintViolationException.class, BadRequestException.class })
+    @ExceptionHandler({ConstraintViolationException.class, BadRequestException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handle(ConstraintViolationException e) {
         return new ExceptionResponse(e.getMessage(), HttpStatus.BAD_REQUEST.value());

--- a/backend/src/main/java/com/darass/darass/exception/dto/ExceptionResponse.java
+++ b/backend/src/main/java/com/darass/darass/exception/dto/ExceptionResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class ExceptionResponse {
+
     private String message;
     private Integer code;
 }

--- a/backend/src/main/java/com/darass/darass/project/domain/Project.java
+++ b/backend/src/main/java/com/darass/darass/project/domain/Project.java
@@ -1,5 +1,6 @@
 package com.darass.darass.project.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import com.darass.darass.user.domain.User;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class Project {
+public class Project extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/darass/darass/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/darass/darass/project/repository/ProjectRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
     Project findBySecretKey(String projectSecretKey);
 
     List<ProjectResponse> findByUserId(Long userId);

--- a/backend/src/main/java/com/darass/darass/project/service/ProjectService.java
+++ b/backend/src/main/java/com/darass/darass/project/service/ProjectService.java
@@ -20,10 +20,10 @@ public class ProjectService {
 
     public ProjectResponse save(ProjectCreateRequest projectRequest, User user) {
         Project project = Project.builder()
-                .name(projectRequest.getName())
-                .secretKey(projectRequest.getSecretKey())
-                .user(user)
-                .build();
+            .name(projectRequest.getName())
+            .secretKey(projectRequest.getSecretKey())
+            .user(user)
+            .build();
         projects.save(project);
         return ProjectResponse.of(project);
     }
@@ -34,7 +34,7 @@ public class ProjectService {
 
     public ProjectResponse findByIdAndUserId(Long projectId, Long userId) {
         Project project = projects.findByIdAndUserId(projectId, userId)
-                .orElseThrow(() -> ExceptionWithMessageAndCode.NOT_FOUND_PROJECT.getException());
+            .orElseThrow(() -> ExceptionWithMessageAndCode.NOT_FOUND_PROJECT.getException());
         return ProjectResponse.of(project);
     }
 

--- a/backend/src/main/java/com/darass/darass/user/domain/User.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.darass.darass.user.domain;
 
+import com.darass.darass.common.domain.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @DiscriminatorColumn(name = "user_type")
 @Getter
 @NoArgsConstructor
-public abstract class User {
+public abstract class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,12 +26,12 @@ public abstract class User {
     @Column(nullable = false)
     private String nickName;
 
-    @Column(name="user_type", insertable = false, updatable = false)
+    @Column(name = "user_type", insertable = false, updatable = false)
     private String userType;
-
-    public abstract boolean isLoginUser();
 
     public User(String nickName) {
         this.nickName = nickName;
     }
+
+    public abstract boolean isLoginUser();
 }

--- a/backend/src/test/java/com/darass/darass/common/domain/BaseTimeEntityTest.java
+++ b/backend/src/test/java/com/darass/darass/common/domain/BaseTimeEntityTest.java
@@ -1,0 +1,44 @@
+package com.darass.darass.common.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.darass.darass.user.domain.OAuthPlatform;
+import com.darass.darass.user.domain.SocialLoginUser;
+import com.darass.darass.user.repository.SocialLoginUserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class BaseTimeEntityTest {
+
+    @Autowired
+    SocialLoginUserRepository socialLoginUserRepository;
+
+    @DisplayName("BaseTimeEntity을 상속한 Entity는 save될 때 생성시간과, 수정시간이 자동으로 저장된다.")
+    @Test
+    public void saveCreatedDateAndModifiedDate() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        socialLoginUserRepository.save(SocialLoginUser.builder()
+            .nickName("병욱")
+            .email("jujubebat@kakao.com")
+            .oauthId("241323123")
+            .oauthPlatform(OAuthPlatform.KAKAO)
+            .build());
+
+        //when
+        List<SocialLoginUser> socialLoginUsers = socialLoginUserRepository.findAll();
+
+        //then
+        SocialLoginUser socialLoginUser = socialLoginUsers.get(0);
+        assertThat(socialLoginUser.getCreatedDate()).isAfter(now);
+        assertThat(socialLoginUser.getModifiedDate()).isAfter(now);
+    }
+
+}


### PR DESCRIPTION
- jacoco 플러그인 추가 했습니다. (build.gradle 파일만 수정됨)
- 인텔리제이 상에서 테스트 코드 돌리면, jacoco 커버리지도 자동으로 같이 측정되게 설정했습니다.
- 테스트 커버리지 리포트 결과는 `build/jacocoHtml/index.html`에서 확인할 수 있습니다.
- 현재 세팅상태는 아래와 같습니다. (builde.gradle에서 세팅 수정가능, 어떤식으로 세팅해야할지 회의필요)
    - 브랜치 커버리지 80프로 이상
    - 라인 커버리지 80프로 이상
    -  코드 라인수 200줄 이하 제한 
- 지금 모든 테스트 코드를 돌려보면 각 테스트는 모두 초록불이 뜨지만 `Test Result`는 노란불이 뜹니다. 이는 위 세팅 조건에 부합하지 않는 코드가 있기 때문 입니다. (커버리지 0프로인 코드가 있음)
- 세팅 간에는 다음 글을 참고했습니다. [Gradle 프로젝트에 JaCoCo 설정하기](https://techblog.woowahan.com/2661/)