### PR TITLE
[FE][관리자 페이지] 스크립트 코드 하이라이팅 추가 (#159)

### DIFF
--- a/frontend/manage/package.json
+++ b/frontend/manage/package.json
@@ -47,6 +47,7 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.18.1",
     "react-router-dom": "^5.2.0",
+    "react-syntax-highlighter": "^15.4.3",
     "styled-components": "^5.3.0"
   },
   "scripts": {

--- a/frontend/manage/src/components/templates/ScriptPublishing/index.tsx
+++ b/frontend/manage/src/components/templates/ScriptPublishing/index.tsx
@@ -1,7 +1,8 @@
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { xcode } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { useCopyButton } from "../../../hooks";
 import ScreenContainer from "../../../styles/ScreenContainer";
-import { Container, Section, Title, CodeBlockWrapper, Content, B, P } from "./styles";
+import { B, CodeBlockWrapper, Container, Content, CopyButton, P, Section, Title } from "./styles";
 
 const scriptCode = (projectSecretKey: string) => `
 <!-- 다라쓰 설치 코드 -->
@@ -27,14 +28,20 @@ export interface Props {
 }
 
 const ScriptPublishing = ({ projectSecretKey }: Props) => {
+  const script = scriptCode(projectSecretKey || "코드를 불러오는 중입니다...");
+  const { isCopyButtonClicked, onCopy } = useCopyButton();
+
   return (
     <ScreenContainer>
       <Container>
         <Section>
           <Title>스크립트</Title>
           <CodeBlockWrapper>
+            <CopyButton type="button" onClick={() => onCopy(script)}>
+              {isCopyButtonClicked ? "Copied !" : "Copy"}
+            </CopyButton>
             <SyntaxHighlighter language="javascript" style={xcode}>
-              {scriptCode(projectSecretKey || "코드를 불러오는 중입니다...")}
+              {script}
             </SyntaxHighlighter>
           </CodeBlockWrapper>
         </Section>

--- a/frontend/manage/src/components/templates/ScriptPublishing/index.tsx
+++ b/frontend/manage/src/components/templates/ScriptPublishing/index.tsx
@@ -1,5 +1,7 @@
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { xcode } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import ScreenContainer from "../../../styles/ScreenContainer";
-import { Container, Section, Title, CodeBlockWrapper, P } from "./styles";
+import { Container, Section, Title, CodeBlockWrapper, Content, B, P } from "./styles";
 
 const scriptCode = (projectSecretKey: string) => `
 <!-- 다라쓰 설치 코드 -->
@@ -17,7 +19,7 @@ const scriptCode = (projectSecretKey: string) => `
     </script>
     <noscript>다라쓰 댓글 작성을 위해 JavaScript를 활성화 해주세요</noscript>
 </div>
-<!-- 다라쓰 설치 코드 끝 --> 
+<!-- 다라쓰 설치 코드 끝 -->
 `;
 
 export interface Props {
@@ -29,22 +31,41 @@ const ScriptPublishing = ({ projectSecretKey }: Props) => {
     <ScreenContainer>
       <Container>
         <Section>
-          <Title>다라쓰 설치 코드</Title>
-          <CodeBlockWrapper>{scriptCode(projectSecretKey || "코드를 불러오는 중입니다...")}</CodeBlockWrapper>
+          <Title>스크립트</Title>
+          <CodeBlockWrapper>
+            <SyntaxHighlighter language="javascript" style={xcode}>
+              {scriptCode(projectSecretKey || "코드를 불러오는 중입니다...")}
+            </SyntaxHighlighter>
+          </CodeBlockWrapper>
         </Section>
 
         <Section>
-          <Title>코드 적용 방법</Title>
-          <P>
-            Condimentum venenatis blandit massa proin nunc, curabitur sit. Lacus dolor ut aliquet semper lorem eros.
-            Ultrices id scelerisque aliquam mattis egestas. Orci ornare varius amet ornare. Nulla nullam imperdiet
-            hendrerit cras enim quis nisi cursus. Elit massa adipiscing fermentum imperdiet vulputate iaculis malesuada.
-            Urna aliquet vitae enim, id in luctus. Risus aliquam amet eu, fames iaculis mauris, metus, sem nascetur.
-            Vulputate ac nibh proin nisi eu fermentum eget eu nulla. Cum id in convallis urna fringilla quam congue
-            turpis. Nibh volutpat a vestibulum tempor purus odio nunc est lacus. Eros libero sed tortor aliquam purus
-            ut. Faucibus at vulputate molestie congue convallis proin proin duis et. Velit tincidunt facilisis vel orci
-            adipiscing id et, vel.
-          </P>
+          <Title>스크립트 적용 가이드</Title>
+
+          <Content>
+            <B>1. 다라쓰 코드 설치</B>
+            <P> 다라쓰를 설치하고자 하는 위치에 홈페이지에서 발급 받은 설치코드를 삽입해주세요.</P>
+          </Content>
+
+          <Content>
+            <B>2. 주의 사항</B>
+            <P>스크립트 내부의 코드는 변경해서는 안됩니다.</P>
+          </Content>
+
+          <Content>
+            <B>3. 브라우저 지원 현황</B>
+            <P>
+              다라쓰는 아래의 최신 브라우저 사용을 권장합니다. 구형 브라우저에서는 일부 기능이 동작하지 않을 수
+              있습니다.
+            </P>
+            <P>
+              <ol>
+                <li>Chrome</li>
+                <li>Safari</li>
+                <li>Samsung browser</li>
+              </ol>
+            </P>
+          </Content>
         </Section>
       </Container>
     </ScreenContainer>

--- a/frontend/manage/src/components/templates/ScriptPublishing/styles.ts
+++ b/frontend/manage/src/components/templates/ScriptPublishing/styles.ts
@@ -22,7 +22,25 @@ const Title = styled.h2`
 const CodeBlockWrapper = styled.div`
   border: 1px solid ${PALETTE.BLACK_700};
   border-radius: 10px;
-  padding: 3rem 2rem;
+  padding: 0 2rem;
+  position: relative;
+`;
+
+const CopyButton = styled.button`
+  position: absolute;
+  right: 1rem;
+  top: 2rem;
+
+  min-width: 10rem;
+  width: fit-content;
+  height: 3.6rem;
+  background-color: ${PALETTE.SECONDARY};
+  color: ${PALETTE.WHITE};
+  font-size: 1.6rem;
+  font-weight: 500;
+  border-radius: 10px;
+  padding: 0.7rem 1.6rem;
+  transform: scale(0.8);
 `;
 
 const Content = styled.div`
@@ -39,4 +57,4 @@ const P = styled.p`
   word-break: keep-all;
 `;
 
-export { Container, Section, Title, CodeBlockWrapper, Content, B, P };
+export { Container, Section, Title, CodeBlockWrapper, Content, B, P, CopyButton };

--- a/frontend/manage/src/components/templates/ScriptPublishing/styles.ts
+++ b/frontend/manage/src/components/templates/ScriptPublishing/styles.ts
@@ -25,9 +25,18 @@ const CodeBlockWrapper = styled.div`
   padding: 3rem 2rem;
 `;
 
+const Content = styled.div`
+  margin-top: 5rem;
+`;
+
+const B = styled.b`
+  font-size: 2rem;
+  word-break: keep-all;
+`;
+
 const P = styled.p`
   font-size: 1.4rem;
   word-break: keep-all;
 `;
 
-export { Container, Section, Title, CodeBlockWrapper, P };
+export { Container, Section, Title, CodeBlockWrapper, Content, B, P };

--- a/frontend/manage/src/hooks/index.ts
+++ b/frontend/manage/src/hooks/index.ts
@@ -3,3 +3,4 @@ export { useUser } from "./useUser";
 export { useGetAllProjects } from "./useGetAllProjects";
 export { useGetProject } from "./useGetProject";
 export { useCreateProject } from "./useCreateProject";
+export { useCopyButton } from "./useCopyButton";

--- a/frontend/manage/src/hooks/useCopyButton.ts
+++ b/frontend/manage/src/hooks/useCopyButton.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+const useCopyButton = () => {
+  const [isCopyButtonClicked, setCopyButtonState] = useState(false);
+
+  const onCopy = (script: string) => {
+    navigator.clipboard.writeText(script);
+    setCopyButtonState(true);
+  };
+
+  return { isCopyButtonClicked, setCopyButtonState, onCopy };
+};
+
+export { useCopyButton };

--- a/frontend/manage/yarn.lock
+++ b/frontend/manage/yarn.lock
@@ -6521,7 +6521,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^10.1.1, highlight.js@~10.7.0:
+highlight.js@^10.1.1, highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
@@ -8142,7 +8142,7 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-lowlight@^1.14.0:
+lowlight@^1.14.0, lowlight@^1.17.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
   integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
@@ -9455,7 +9455,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.21.0, prismjs@~1.24.0:
+prismjs@^1.21.0, prismjs@^1.22.0, prismjs@~1.24.0:
   version "1.24.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
   integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
@@ -9895,6 +9895,17 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
+react-syntax-highlighter@^15.4.3:
+  version "15.4.3"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz#fffe3286677ac470b963b364916d16374996f3a6"
+  integrity sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.22.0"
+    refractor "^3.2.0"
+
 react-textarea-autosize@^8.3.0:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz#f70913945369da453fd554c168f6baacd1fa04d8"
@@ -9983,7 +9994,7 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
-refractor@^3.1.0:
+refractor@^3.1.0, refractor@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.4.0.tgz#62bd274b06c942041f390c371b676eb67cb0a678"
   integrity sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==


### PR DESCRIPTION
- react-syntax-highlighter 라이브러리를 사용하여 스크립트 하이라이팅 추가 
  - 스타일은 제 기준 가장 알맞다고 판단되는 것을 넣었습니다.
  - 가장 많이 사용되는 하이라이팅용 react 라이브러리를 사용하였습니다. (어차피 하이라이팅하려면 highlight.js 같은 서드파티 라이브러리 무조건 써야함)

- 스크립트 카피 버튼을 만들었습니다.
  - 저 버튼은 스크립트가 존재하는 모든 곳에 사용될 수 있으므로, 로직을 커스텀훅으로 추출했습니다.
  - 스타일은 제 마음대로 주었습니다.
![Jul-17-2021 20-43-23](https://user-images.githubusercontent.com/42544600/126035816-603f2fc8-93b5-4174-82e2-c7ae049752f5.gif)


- 스크립트 적용 방법 등, 컨텐츠의 이름을 바꾸었습니다.
  - 라이브리의 적용가이드를 참고했습니다.

