### PR TITLE
[FE][댓글모듈] 비로그인 유저 비밀번호 입력창을 수동으로 닫을 수 있게 만든다. (#257)

### DIFF
--- a/frontend/manage/src/constants/api.ts
+++ b/frontend/manage/src/constants/api.ts
@@ -1,6 +1,6 @@
 const BASE_URL = "https://darass.o-r.kr";
 const QUERY = {
-  LOGIN: "/api/v1/login/oauth?oauthAccessToken=",
+  LOGIN: "/api/v1/login/oauth?oauthProviderName=kakao&oauthAccessToken=",
   USER: "/api/v1/users",
   COMMENT: "/api/v1/comments",
   PROJECT: "/api/v1/projects"

--- a/frontend/reply-module/.babelrc
+++ b/frontend/reply-module/.babelrc
@@ -9,5 +9,8 @@
     ],
     "@babel/preset-typescript"
   ],
-  "plugins": [["@babel/transform-runtime"]]
+  "plugins": [
+    ["@babel/transform-runtime"],
+    ["babel-plugin-remove-react-jsx-attribute", { "attributes": ["data-testid"] }]
+  ]
 }

--- a/frontend/reply-module/package.json
+++ b/frontend/reply-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reply-module",
-  "version": "^0.1.1",
+  "version": "^0.1.2",
   "description": "댓글 모듈",
   "main": "index.js",
   "author": "도비, 곤이",

--- a/frontend/reply-module/package.json
+++ b/frontend/reply-module/package.json
@@ -26,6 +26,7 @@
     "@types/styled-components": "^5.1.11",
     "@types/testing-library__jest-dom": "^5.14.0",
     "babel-loader": "^8.2.2",
+    "babel-plugin-remove-react-jsx-attribute": "^1.0.1",
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",

--- a/frontend/reply-module/src/__test__/intergration/guestUserComment.test.tsx
+++ b/frontend/reply-module/src/__test__/intergration/guestUserComment.test.tsx
@@ -41,7 +41,13 @@ describe("비로그인 유저 댓글 조회", () => {
     (useConfirmGuestPassword as jest.Mock).mockImplementation(() => {
       return {
         isValid: true,
-        getPasswordConfirmResult: () => true
+        getPasswordConfirmResult: () => {
+          return {
+            data: {
+              isCorrectPassword: true
+            }
+          };
+        }
       };
     });
   });
@@ -145,7 +151,13 @@ describe("비로그인 유저 댓글 수정", () => {
     (useConfirmGuestPassword as jest.Mock).mockImplementation(() => {
       return {
         isValid: true,
-        getPasswordConfirmResult: () => true
+        getPasswordConfirmResult: () => {
+          return {
+            data: {
+              isCorrectPassword: true
+            }
+          };
+        }
       };
     });
   });
@@ -190,7 +202,13 @@ describe("비로그인 유저 댓글 삭제", () => {
     (useConfirmGuestPassword as jest.Mock).mockImplementation(() => {
       return {
         isValid: true,
-        getPasswordConfirmResult: () => true
+        getPasswordConfirmResult: () => {
+          return {
+            data: {
+              isCorrectPassword: true
+            }
+          };
+        }
       };
     });
   });

--- a/frontend/reply-module/src/__test__/intergration/login.test.tsx
+++ b/frontend/reply-module/src/__test__/intergration/login.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/extend-expect";
 import { render, waitFor } from "@testing-library/react";
+import Avatar from "../../components/atoms/Avatar";
 import UserAvatarOption from "../../components/molecules/UserAvatarOption";
 import { useUser } from "../../hooks";
 import { User } from "../../types/user";
@@ -30,21 +31,15 @@ describe("댓글모듈 Login 기능", () => {
             로그아웃
           </button>
         ) : (
-          <button type="button" onClick={() => {}}>
-            카카오로 로그인
-          </button>
+          <Avatar size="SM" alt="카카오톡 로그인 이미지" />
         )}
       </UserAvatarOption>
     );
 
-    userAvatarOption.getByRole("img").click();
+    userAvatarOption.getByTestId("avatar-img").click();
 
     await waitFor(() => {
-      expect(
-        userAvatarOption.getByRole("button", {
-          name: /카카오로 로그인/i
-        })
-      ).toBeInTheDocument();
+      expect(userAvatarOption.getByAltText("카카오톡 로그인 이미지")).toBeInTheDocument();
     });
   });
 
@@ -70,25 +65,19 @@ describe("댓글모듈 Login 기능", () => {
             로그아웃
           </button>
         ) : (
-          <button type="button" onClick={() => {}}>
-            카카오로 로그인
-          </button>
+          <Avatar size="SM" alt="카카오톡 로그인 이미지" />
         )}
       </UserAvatarOption>
     );
 
-    userAvatarOption.getByRole("img").click();
+    userAvatarOption.getByTestId("avatar-img").click();
 
-    await waitFor(async () => {
-      userAvatarOption.getByRole("img").click();
-
-      await waitFor(() => {
-        expect(
-          userAvatarOption.getByRole("button", {
-            name: /로그아웃/i
-          })
-        ).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      expect(
+        userAvatarOption.getByRole("button", {
+          name: /로그아웃/i
+        })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/reply-module/src/components/atoms/Avatar/index.tsx
+++ b/frontend/reply-module/src/components/atoms/Avatar/index.tsx
@@ -11,7 +11,9 @@ export interface Props {
 }
 
 const Avatar = ({ imageURL, size = "MD", onClick, alt }: Props) => {
-  return <Container src={imageURL || defaultUserImage} size={size} onClick={onClick} alt={alt} />;
+  return (
+    <Container src={imageURL || defaultUserImage} size={size} onClick={onClick} alt={alt} data-testid="avatar-img" />
+  );
 };
 
 export default Avatar;

--- a/frontend/reply-module/src/components/atoms/CommentOption/index.tsx
+++ b/frontend/reply-module/src/components/atoms/CommentOption/index.tsx
@@ -35,12 +35,12 @@ const CommentOption = ({ className, startEditing, startDeleting }: Props) => {
       {isShowOptionBox && (
         <OptionContainer>
           {startEditing && (
-            <EditButton type="button" onClick={onEdit}>
+            <EditButton type="button" onClick={onEdit} data-testid="comment-option-edit-button">
               수정
             </EditButton>
           )}
           {startDeleting && (
-            <DeleteButton type="button" onClick={onDelete}>
+            <DeleteButton type="button" onClick={onDelete} data-testid="comment-option-delete-button">
               삭제
             </DeleteButton>
           )}

--- a/frontend/reply-module/src/components/atoms/CommentTextBox/styles.ts
+++ b/frontend/reply-module/src/components/atoms/CommentTextBox/styles.ts
@@ -29,7 +29,7 @@ const Text = styled.div`
 const Button = styled.button`
   width: 4rem;
   height: 2.4rem;
-  background-color: ${PALETTE.PRIMARY};
+  background-color: ${PALETTE.SECONDARY};
   color: ${PALETTE.WHITE};
   font-size: 1.2rem;
   font-weight: 500;

--- a/frontend/reply-module/src/components/molecules/Comment/index.tsx
+++ b/frontend/reply-module/src/components/molecules/Comment/index.tsx
@@ -11,6 +11,7 @@ import Avatar from "../../atoms/Avatar";
 import CommentTextBox from "../../atoms/CommentTextBox";
 import {
   Button,
+  CancelButton,
   CommentOption,
   CommentTextBoxWrapper,
   CommentWrapper,
@@ -49,8 +50,6 @@ const Comment = ({ user, comment, align = "left", shouldShowOption, iAmAdmin, th
   };
 
   const canIControl = (iAmAdmin && thisCommentIsMine) || !iAmAdmin;
-
-  const isEditable = (iAmAdmin && thisCommentIsMine) || !iAmAdmin;
 
   const confirmGuestPassword = async () => {
     try {
@@ -180,6 +179,9 @@ const Comment = ({ user, comment, align = "left", shouldShowOption, iAmAdmin, th
               placeholder="댓글 작성 시 입력한 비밀번호 입력"
               isValidInput={!isPasswordSubmitted}
             />
+            <CancelButton type="button" onClick={() => clear()}>
+              취소
+            </CancelButton>
             <Button>입력</Button>
           </PasswordForm>
         )}

--- a/frontend/reply-module/src/components/molecules/Comment/index.tsx
+++ b/frontend/reply-module/src/components/molecules/Comment/index.tsx
@@ -40,7 +40,7 @@ const Comment = ({ user, comment, align = "left", shouldShowOption, iAmAdmin, th
   const { value: password, setValue: setPassword, onChange: onChangePassword } = useInput("");
   const { editComment } = useEditComment();
   const { deleteComment } = useDeleteComment();
-  const { isValid, getPasswordConfirmResult } = useConfirmGuestPassword({
+  const { getPasswordConfirmResult } = useConfirmGuestPassword({
     guestUserId: comment.user.id,
     guestUserPassword: password
   });
@@ -57,9 +57,9 @@ const Comment = ({ user, comment, align = "left", shouldShowOption, iAmAdmin, th
 
   const confirmGuestPassword = async () => {
     try {
-      await getPasswordConfirmResult();
+      const { data } = await getPasswordConfirmResult();
 
-      return isValid;
+      return !!data?.isCorrectPassword;
     } catch (error) {
       console.error(error.message);
       setPasswordSubmitted(true);
@@ -102,6 +102,8 @@ const Comment = ({ user, comment, align = "left", shouldShowOption, iAmAdmin, th
     event.preventDefault();
 
     const isValidPassword = await confirmGuestPassword();
+
+    console.log(isValidPassword);
 
     if (!isValidPassword) {
       alert("비밀번호가 일치하지 않습니다.");

--- a/frontend/reply-module/src/components/molecules/Comment/styles.ts
+++ b/frontend/reply-module/src/components/molecules/Comment/styles.ts
@@ -61,4 +61,19 @@ const Button = styled.button`
   }
 `;
 
-export { Container, CommentWrapper, CommentTextBoxWrapper, Time, CommentOption, PasswordForm, PasswordInput, Button };
+const CancelButton = styled(Button)`
+  background-color: ${PALETTE.RED_600};
+  margin-right: 0.5rem;
+`;
+
+export {
+  Container,
+  CommentWrapper,
+  CommentTextBoxWrapper,
+  Time,
+  CommentOption,
+  PasswordForm,
+  PasswordInput,
+  Button,
+  CancelButton
+};

--- a/frontend/reply-module/src/components/molecules/Comment/styles.ts
+++ b/frontend/reply-module/src/components/molecules/Comment/styles.ts
@@ -48,7 +48,7 @@ const PasswordInput = styled.input<{ isValidInput: Boolean }>`
 const Button = styled.button`
   width: 4rem;
   height: 2.4rem;
-  background-color: ${PALETTE.PRIMARY};
+  background-color: ${PALETTE.SECONDARY};
   color: ${PALETTE.WHITE};
   font-size: 1.2rem;
   font-weight: 500;

--- a/frontend/reply-module/src/components/molecules/UserAvatarOption/index.tsx
+++ b/frontend/reply-module/src/components/molecules/UserAvatarOption/index.tsx
@@ -22,7 +22,12 @@ const UserAvatarOption = ({ user, children }: Props) => {
   return (
     <Container>
       <UserNickName onClick={onShowOptionBox}>{user?.nickName ?? "로그인"}</UserNickName>
-      <Avatar imageURL={user?.profileImageUrl} onClick={onShowOptionBox} alt="유저 프로필 이미지" />
+      <Avatar
+        imageURL={user?.profileImageUrl}
+        onClick={onShowOptionBox}
+        alt="유저 프로필 이미지"
+        data-testid="avartar-option-img"
+      />
       {isShowOptionBox && <UserOption userName={user?.nickName || "Login With"}>{children}</UserOption>}
     </Container>
   );

--- a/frontend/reply-module/src/components/organisms/CommentList/index.tsx
+++ b/frontend/reply-module/src/components/organisms/CommentList/index.tsx
@@ -29,7 +29,7 @@ const CommentList = ({ className, comments, user, project }: Props) => {
             const authorId = comment.user.id;
 
             const iAmGuestUser = !user;
-            const iAmAdmin = project?.userId === user?.id;
+            const iAmAdmin = user !== undefined && project?.userId === user.id;
 
             const thisCommentIsMine = authorId === user?.id;
             const thisCommentIsWrittenByGuest = comment.user.type === "GuestUser";

--- a/frontend/reply-module/src/constants/api.ts
+++ b/frontend/reply-module/src/constants/api.ts
@@ -1,7 +1,7 @@
 import { GuestUserInfo } from "../types/comment";
 const BASE_URL = "https://darass.o-r.kr";
 const QUERY = {
-  LOGIN: "/api/v1/login/oauth?oauthAccessToken=",
+  LOGIN: "/api/v1/login/oauth?oauthProviderName=kakao&oauthAccessToken=",
   COMMENT: "/api/v1/comments",
   GET_ALL_COMMENTS: (url: string, projectKey: string) => `/api/v1/comments?url=${url}&projectKey=${projectKey}`,
   GET_PROJECT: (projectKey: string) => `/api/v1/projects/user-id?secretKey=${projectKey}`,

--- a/frontend/reply-module/src/constants/reactQueryKey.ts
+++ b/frontend/reply-module/src/constants/reactQueryKey.ts
@@ -1,7 +1,8 @@
 const REACT_QUERY_KEY = {
   USER: "user",
   COMMENT: "comment",
-  PROJECT: "project"
+  PROJECT: "project",
+  GUEST_PASSWORD_CONFIRM: "guest-password-confirm"
 };
 
 export { REACT_QUERY_KEY };

--- a/frontend/reply-module/src/hooks/index.ts
+++ b/frontend/reply-module/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useEditComment } from "./useEditComment";
 export { useDeleteComment } from "./useDeleteComment";
 export { useInput } from "./useInput";
 export { useProject } from "./useProject";
+export { useConfirmGuestPassword } from "./useConfirmGuestPassword";

--- a/frontend/reply-module/src/hooks/useConfirmGuestPassword.ts
+++ b/frontend/reply-module/src/hooks/useConfirmGuestPassword.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "react-query";
+import { QUERY } from "../constants/api";
+import { REACT_QUERY_KEY } from "../constants/reactQueryKey";
+import { GuestUserInfo } from "../types/comment";
+import { request } from "../utils/request";
+
+const _getPasswordConfirmResult = async ({ guestUserId, guestUserPassword }: GuestUserInfo) => {
+  const response = await request.get(QUERY.CHECK_GUEST_PASSWORD({ guestUserId, guestUserPassword }));
+
+  if (response.status >= 400) {
+    throw new Error(response.data.message);
+  }
+
+  return response.data;
+};
+
+const useConfirmGuestPassword = ({ guestUserId, guestUserPassword }: GuestUserInfo) => {
+  const {
+    data,
+    isLoading,
+    error,
+    refetch: getPasswordConfirmResult
+  } = useQuery<
+    {
+      isCorrectPassword: false;
+    },
+    Error
+  >(REACT_QUERY_KEY.GUEST_PASSWORD_CONFIRM, () => _getPasswordConfirmResult({ guestUserId, guestUserPassword }), {
+    enabled: false,
+    retryOnMount: false,
+    retry: false,
+    cacheTime: 0,
+    refetchOnWindowFocus: false
+  });
+
+  const isValid = data?.isCorrectPassword;
+
+  return { isValid, isLoading, error, getPasswordConfirmResult };
+};
+
+export { useConfirmGuestPassword };

--- a/frontend/reply-module/src/hooks/useConfirmGuestPassword.ts
+++ b/frontend/reply-module/src/hooks/useConfirmGuestPassword.ts
@@ -15,12 +15,7 @@ const _getPasswordConfirmResult = async ({ guestUserId, guestUserPassword }: Gue
 };
 
 const useConfirmGuestPassword = ({ guestUserId, guestUserPassword }: GuestUserInfo) => {
-  const {
-    data,
-    isLoading,
-    error,
-    refetch: getPasswordConfirmResult
-  } = useQuery<
+  const { refetch: getPasswordConfirmResult } = useQuery<
     {
       isCorrectPassword: false;
     },
@@ -33,9 +28,7 @@ const useConfirmGuestPassword = ({ guestUserId, guestUserPassword }: GuestUserIn
     refetchOnWindowFocus: false
   });
 
-  const isValid = data?.isCorrectPassword;
-
-  return { isValid, isLoading, error, getPasswordConfirmResult };
+  return { getPasswordConfirmResult };
 };
 
 export { useConfirmGuestPassword };

--- a/frontend/reply-module/yarn.lock
+++ b/frontend/reply-module/yarn.lock
@@ -3679,6 +3679,11 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
+babel-plugin-remove-react-jsx-attribute@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-react-jsx-attribute/-/babel-plugin-remove-react-jsx-attribute-1.0.1.tgz#89e807ecb871d5dd2cd760879a1a661235d56eb6"
+  integrity sha512-I5YPG1jcm9it9rd6bA5Wrl88y4myav09sNUch/XcwAeV2Rgp3n2WybhBZLT3+d5Pja4toou6aTt/cGX+la5LCA==
+
 "babel-plugin-styled-components@>= 1.12.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.1.tgz#5ecd28b207627c2a26ef8d5da401e9644065095a"


### PR DESCRIPTION
- 비로그인 유저 비밀번호 입력창을 수동으로 닫을 수 있게 만들었습니다.
- 해당 기능 추가로 인해 발생한 테스트 코드를 리팩터링하였습니다.
  - Comment의 confirmGuestPassword(?)가 함수안에 함수 형식이라 Mocking이 되지 않아서 useQuery로 커스텀 hook 분리하였습니다.
  대신, 선언시 바로 fetch하는게 아니라, 수동으로 refetch해야 요청이 되도록 설정을 주었습니다.
- <del>현재 서버 로그인이 안되어서 웹 사이트에서 수동으로 테스트하진 못했습니다.</del>
- 테스트되었습니다.


https://user-images.githubusercontent.com/42544600/126765906-e69d70e9-5aad-410a-b2e9-5c5ca21f6303.mov



