### PR TITLE
[BE] 유저 닉네임 수정, 프로필 사진 변경 기능 (#274)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
     // 로깅
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+
+    // aws s3 sdk
+    implementation platform('software.amazon.awssdk:bom:2.15.0')
+    implementation 'software.amazon.awssdk:s3:2.17.5'
 }
 
 test {

--- a/backend/src/docs/asciidoc/api/v1/users.adoc
+++ b/backend/src/docs/asciidoc/api/v1/users.adoc
@@ -21,7 +21,7 @@ include::{snippets}/api/v1/users/get/fail/response-fields.adoc[]
 
 include::{snippets}/api/v1/users/patch/success/http-request.adoc[]
 include::{snippets}/api/v1/users/patch/success/request-headers.adoc[]
-include::{snippets}/api/v1/users/patch/success/request-fields.adoc[]
+include::{snippets}/api/v1/users/patch/success/request-parts.adoc[]
 
 ==== Response (성공 - 소셜 로그인 유저 닉네임 수정)
 

--- a/backend/src/main/java/com/darass/darass/auth/oauth/service/OAuthService.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/service/OAuthService.java
@@ -29,14 +29,11 @@ public class OAuthService {
             .findByOauthId(socialLoginUser.getOauthId());
 
         if (possibleSocialLoginUser.isEmpty()) { //TODO: 옵셔널로 변경 가능?
-
             socialLoginUserRepository.save(socialLoginUser);
             return TokenResponse.of(jwtTokenProvider.createAccessToken(socialLoginUser.getId().toString()));
         }
 
         SocialLoginUser foundSocialLoginUser = possibleSocialLoginUser.get();
-        foundSocialLoginUser.update(socialLoginUser);
-
         return TokenResponse.of(jwtTokenProvider.createAccessToken(foundSocialLoginUser.getId().toString()));
     }
 

--- a/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
+++ b/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
@@ -1,5 +1,6 @@
 package com.darass.darass.exception;
 
+import com.darass.darass.exception.httpbasicexception.BadRequestException;
 import com.darass.darass.exception.httpbasicexception.ConflictException;
 import com.darass.darass.exception.httpbasicexception.CustomException;
 import com.darass.darass.exception.httpbasicexception.InternalServerException;
@@ -31,8 +32,8 @@ public enum ExceptionWithMessageAndCode {
     NOT_GUEST_USER(new UnauthorizedException("Guest 사용자가 아닙니다.", 902)),
     UNAUTHORIZED_FOR_COMMENT(new UnauthorizedException("해당 댓글을 관리할 권한이 없습니다.", 903)),
 
-    // AWS 관련 : 10xx
-    AWS_SDK_CLIENT_EXCEPTION(new UnauthorizedException("S3에 업로드할 권한이 없습니다.", 1000));
+    // 파일 관련 : 10xx
+    IO_EXCEPTION(new BadRequestException("업로드할 파일이 잘못되었습니다.", 1000));
 
     private final CustomException exception;
 

--- a/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
+++ b/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
@@ -29,7 +29,10 @@ public enum ExceptionWithMessageAndCode {
     NOT_FOUND_COMMENT(new NotFoundException("해당하는 댓글이 없습니다.", 900)),
     INVALID_GUEST_PASSWORD(new UnauthorizedException("Guest 사용자의 비밀번호가 일치하지 않습니다.", 901)),
     NOT_GUEST_USER(new UnauthorizedException("Guest 사용자가 아닙니다.", 902)),
-    UNAUTHORIZED_FOR_COMMENT(new UnauthorizedException("해당 댓글을 관리할 권한이 없습니다.", 903));
+    UNAUTHORIZED_FOR_COMMENT(new UnauthorizedException("해당 댓글을 관리할 권한이 없습니다.", 903)),
+
+    // AWS 관련 : 10xx
+    AWS_SDK_CLIENT_EXCEPTION(new UnauthorizedException("S3에 업로드할 권한이 없습니다.", 1000));
 
     private final CustomException exception;
 

--- a/backend/src/main/java/com/darass/darass/exception/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/darass/darass/exception/controller/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.darass.darass.exception.controller;
 
 import com.darass.darass.exception.dto.ExceptionResponse;
+import com.darass.darass.exception.httpbasicexception.BadRequestException;
 import com.darass.darass.exception.httpbasicexception.ConflictException;
 import com.darass.darass.exception.httpbasicexception.NotFoundException;
 import com.darass.darass.exception.httpbasicexception.UnauthorizedException;
@@ -19,6 +20,12 @@ public class ControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         return new ExceptionResponse(e.getMessage(), HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ExceptionResponse handleBadRequestException(UnauthorizedException e) {
+        return new ExceptionResponse(e.getMessage(), e.getCode());
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/src/main/java/com/darass/darass/exception/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/darass/darass/exception/controller/ControllerAdvice.java
@@ -24,7 +24,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(BadRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ExceptionResponse handleBadRequestException(UnauthorizedException e) {
+    public ExceptionResponse handleBadRequestException(BadRequestException e) {
         return new ExceptionResponse(e.getMessage(), e.getCode());
     }
 

--- a/backend/src/main/java/com/darass/darass/exception/httpbasicexception/BadRequestException.java
+++ b/backend/src/main/java/com/darass/darass/exception/httpbasicexception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.darass.darass.exception.httpbasicexception;
+
+public class BadRequestException extends CustomException {
+
+    public BadRequestException(String message, Integer code) {
+        super(message, code);
+    }
+}

--- a/backend/src/main/java/com/darass/darass/user/S3ClientConfig.java
+++ b/backend/src/main/java/com/darass/darass/user/S3ClientConfig.java
@@ -1,0 +1,16 @@
+package com.darass.darass.user;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3ClientConfig {
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+            .region(Region.AP_NORTHEAST_2)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/darass/darass/user/controller/UserController.java
+++ b/backend/src/main/java/com/darass/darass/user/controller/UserController.java
@@ -14,9 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @AllArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -33,10 +31,8 @@ public class UserController {
 
     @PatchMapping
     public ResponseEntity<UserResponse> updateNickname(@RequiredLogin User user,
-        @RequestParam(name = "nickName", required = false) String nickName,
-        @RequestParam(name = "profileImageFile", required = false) MultipartFile profileImageFile
+        @ModelAttribute UserUpdateRequest userUpdateRequest
     ) {
-        UserUpdateRequest userUpdateRequest = new UserUpdateRequest(nickName, profileImageFile);
         UserResponse userResponse = userService.update(user.getId(), userUpdateRequest);
         return ResponseEntity.ok(userResponse);
     }

--- a/backend/src/main/java/com/darass/darass/user/controller/UserController.java
+++ b/backend/src/main/java/com/darass/darass/user/controller/UserController.java
@@ -7,25 +7,16 @@ import com.darass.darass.user.dto.PasswordCheckResponse;
 import com.darass.darass.user.dto.UserResponse;
 import com.darass.darass.user.dto.UserUpdateRequest;
 import com.darass.darass.user.service.UserService;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Optional;
-import javax.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @AllArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -42,8 +33,11 @@ public class UserController {
 
     @PatchMapping
     public ResponseEntity<UserResponse> updateNickname(@RequiredLogin User user,
-        @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
-        UserResponse userResponse = userService.updateNickName(user.getId(), userUpdateRequest);
+        @RequestParam(name = "nickName", required = false) String nickName,
+        @RequestParam(name = "profileImageFile", required = false) MultipartFile profileImageFile
+    ) {
+        UserUpdateRequest userUpdateRequest = new UserUpdateRequest(nickName, profileImageFile);
+        UserResponse userResponse = userService.update(user.getId(), userUpdateRequest);
         return ResponseEntity.ok(userResponse);
     }
 
@@ -58,28 +52,5 @@ public class UserController {
         @ModelAttribute PasswordCheckRequest passwordCheckRequest) {
         PasswordCheckResponse passwordCheckResponse = userService.checkGuestUserPassword(passwordCheckRequest);
         return ResponseEntity.ok(passwordCheckResponse);
-    }
-
-    @PatchMapping("/test")
-    public ResponseEntity<Void> test(@RequestParam("data") MultipartFile multipartFile) throws IOException {
-        System.out.println(multipartFile);
-        File file = new File(multipartFile.getOriginalFilename());
-        if (file.createNewFile()) {
-            try (FileOutputStream fos = new FileOutputStream(file)) {
-                fos.write(multipartFile.getBytes());
-            }
-        }
-
-        Region region = Region.AP_NORTHEAST_2;
-        S3Client s3 = S3Client.builder()
-            .region(region)
-            .build();
-        PutObjectRequest objectRequest = PutObjectRequest.builder()
-            .bucket("darass-user-profile-image")
-            .key(file.getName())
-            .build();
-        s3.putObject(objectRequest, software.amazon.awssdk.core.sync.RequestBody.fromFile(file));
-        file.delete();
-        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
@@ -51,12 +51,8 @@ public class SocialLoginUser extends User {
             changeNickName(nickName);
         }
         if (!Objects.isNull(profileImageFile)) {
-            try {
-                String imageUrl = s3Uploader.upload(profileImageFile);
-                changeProfileImageUrl(imageUrl);
-            } catch (IOException e) {
-                throw ExceptionWithMessageAndCode.IO_EXCEPTION.getException();
-            }
+            String imageUrl = s3Uploader.upload(profileImageFile);
+            changeProfileImageUrl(imageUrl);
         }
     }
 }

--- a/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
@@ -55,7 +55,7 @@ public class SocialLoginUser extends User {
                 String imageUrl = s3Uploader.upload(profileImageFile);
                 changeProfileImageUrl(imageUrl);
             } catch (IOException e) {
-                throw ExceptionWithMessageAndCode.INTERNAL_SERVER.getException();
+                throw ExceptionWithMessageAndCode.IO_EXCEPTION.getException();
             }
         }
     }

--- a/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
@@ -45,14 +45,6 @@ public class SocialLoginUser extends User {
         throw ExceptionWithMessageAndCode.NOT_GUEST_USER.getException();
     }
 
-    public void update(SocialLoginUser socialLoginUser) {
-        this.changeNickName(socialLoginUser.getNickName());
-        this.changeProfileImageUrl(socialLoginUser.getProfileImageUrl());
-        this.email = socialLoginUser.getEmail();
-        this.oauthId = socialLoginUser.getOauthId();
-        this.oauthProviderType = socialLoginUser.getOauthProviderType();
-    }
-
     public void changeNickNameOrProfileImageIfExists(S3Uploader s3Uploader, String nickName,
         MultipartFile profileImageFile) {
         if (!Objects.isNull(nickName)) {

--- a/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/SocialLoginUser.java
@@ -2,12 +2,17 @@ package com.darass.darass.user.domain;
 
 import com.darass.darass.auth.oauth.api.domain.OAuthProviderType;
 import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import com.darass.darass.user.infrastructure.S3Uploader;
+import java.io.IOException;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 @Getter
 @NoArgsConstructor
@@ -46,5 +51,20 @@ public class SocialLoginUser extends User {
         this.email = socialLoginUser.getEmail();
         this.oauthId = socialLoginUser.getOauthId();
         this.oauthProviderType = socialLoginUser.getOauthProviderType();
+    }
+
+    public void changeNickNameOrProfileImageIfExists(S3Uploader s3Uploader, String nickName,
+        MultipartFile profileImageFile) {
+        if (!Objects.isNull(nickName)) {
+            changeNickName(nickName);
+        }
+        if (!Objects.isNull(profileImageFile)) {
+            try {
+                String imageUrl = s3Uploader.upload(profileImageFile);
+                changeProfileImageUrl(imageUrl);
+            } catch (IOException e) {
+                throw ExceptionWithMessageAndCode.INTERNAL_SERVER.getException();
+            }
+        }
     }
 }

--- a/backend/src/main/java/com/darass/darass/user/domain/User.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/User.java
@@ -88,15 +88,4 @@ public abstract class User extends BaseTimeEntity {
     public void changeProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }
-
-    public void changeNickNameOrProfileImageIfExists(S3Uploader s3Uploader, String nickName,
-        MultipartFile profileImageFile) {
-        if (!Objects.isNull(nickName)) {
-            changeNickName(nickName);
-        }
-        if (!Objects.isNull(profileImageFile)) {
-            String imageUrl = s3Uploader.upload(profileImageFile);
-            changeProfileImageUrl(imageUrl);
-        }
-    }
 }

--- a/backend/src/main/java/com/darass/darass/user/domain/User.java
+++ b/backend/src/main/java/com/darass/darass/user/domain/User.java
@@ -7,8 +7,10 @@ import com.darass.darass.comment.domain.Comment;
 import com.darass.darass.comment.domain.CommentLike;
 import com.darass.darass.common.domain.BaseTimeEntity;
 import com.darass.darass.project.domain.Project;
+import com.darass.darass.user.infrastructure.S3Uploader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -20,6 +22,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor
@@ -86,4 +89,14 @@ public abstract class User extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void changeNickNameOrProfileImageIfExists(S3Uploader s3Uploader, String nickName,
+        MultipartFile profileImageFile) {
+        if (!Objects.isNull(nickName)) {
+            changeNickName(nickName);
+        }
+        if (!Objects.isNull(profileImageFile)) {
+            String imageUrl = s3Uploader.upload(profileImageFile);
+            changeProfileImageUrl(imageUrl);
+        }
+    }
 }

--- a/backend/src/main/java/com/darass/darass/user/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/com/darass/darass/user/dto/UserUpdateRequest.java
@@ -3,10 +3,12 @@ package com.darass.darass.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @NoArgsConstructor
 @Getter
+@Setter
 @AllArgsConstructor
 public class UserUpdateRequest {
 

--- a/backend/src/main/java/com/darass/darass/user/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/com/darass/darass/user/dto/UserUpdateRequest.java
@@ -1,17 +1,18 @@
 package com.darass.darass.user.dto;
 
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @NoArgsConstructor
 @Getter
 @AllArgsConstructor
 public class UserUpdateRequest {
 
-    @NotNull
     private String nickName;
+
+    private MultipartFile profileImageFile;
 
 }
 

--- a/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
+++ b/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
@@ -5,43 +5,28 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Date;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
+@RequiredArgsConstructor
 public class S3Uploader {
 
     private static final String S3_BUCKET_NAME = "darass-user-profile-image";
     private static final String CLOUDFRONT_URL = "https://d3qmnph7nb4773.cloudfront.net/";
-    private Region region;
+    private final S3Client s3;
 
-    private S3Client s3;
-
-    public S3Uploader() {
-        this.region = Region.AP_NORTHEAST_2;
-        this.s3 = S3Client.builder()
-            .region(region)
-            .build();
-    }
-
-    public String upload(MultipartFile multipartFile) {
+    public String upload(MultipartFile multipartFile) throws IOException {
         File uploadFile;
+        uploadFile = convert(multipartFile);
         try {
-            uploadFile = convert(multipartFile);
-        } catch (IOException e) {
-            throw ExceptionWithMessageAndCode.INTERNAL_SERVER.getException();
-        }
-
-        try {
-            String uploadImageUrl = upload(uploadFile);
+            String uploadImageUrl = uploadToS3(uploadFile);
             return uploadImageUrl;
-        } catch (SdkClientException e) {
-            throw ExceptionWithMessageAndCode.AWS_SDK_CLIENT_EXCEPTION.getException();
         } finally {
             removeNewFile(uploadFile);
         }
@@ -55,7 +40,7 @@ public class S3Uploader {
         return file;
     }
 
-    private String upload(File uploadFile) {
+    private String uploadToS3(File uploadFile) {
         String fileName = new Date().getTime() + uploadFile.getName();
         PutObjectRequest objectRequest = PutObjectRequest.builder()
             .bucket(S3_BUCKET_NAME)

--- a/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
+++ b/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
@@ -1,2 +1,72 @@
-package com.darass.darass.user.infrastructure;public class S3Uploader {
+package com.darass.darass.user.infrastructure;
+
+import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+public class S3Uploader {
+
+    private static final String S3_BUCKET_NAME = "darass-user-profile-image";
+    private static final String CLOUDFRONT_URL = "https://d3qmnph7nb4773.cloudfront.net/";
+    private Region region;
+
+    private S3Client s3;
+
+    public S3Uploader() {
+        this.region = Region.AP_NORTHEAST_2;
+        this.s3 = S3Client.builder()
+            .region(region)
+            .build();
+    }
+
+    public String upload(MultipartFile multipartFile) {
+        File uploadFile;
+        try {
+            uploadFile = convert(multipartFile);
+        } catch (IOException e) {
+            throw ExceptionWithMessageAndCode.INTERNAL_SERVER.getException();
+        }
+
+        try {
+            String uploadImageUrl = upload(uploadFile);
+            return uploadImageUrl;
+        } catch (SdkClientException e) {
+            throw ExceptionWithMessageAndCode.AWS_SDK_CLIENT_EXCEPTION.getException();
+        } finally {
+            removeNewFile(uploadFile);
+        }
+    }
+
+    private File convert(MultipartFile multipartFile) throws IOException{
+        File file = new File(multipartFile.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(multipartFile.getBytes());
+        }
+        return file;
+    }
+
+    private String upload(File uploadFile) {
+        String fileName = new Date().getTime() + uploadFile.getName();
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+            .bucket(S3_BUCKET_NAME)
+            .key(fileName)
+            .build();
+        s3.putObject(objectRequest, RequestBody.fromFile(uploadFile));
+        String uploadFileUrl = CLOUDFRONT_URL + fileName;
+        return uploadFileUrl;
+    }
+
+    private void removeNewFile(File uploadFile) {
+        uploadFile.delete();
+    }
 }

--- a/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
+++ b/backend/src/main/java/com/darass/darass/user/infrastructure/S3Uploader.java
@@ -1,0 +1,2 @@
+package com.darass.darass.user.infrastructure;public class S3Uploader {
+}

--- a/backend/src/main/java/com/darass/darass/user/service/UserService.java
+++ b/backend/src/main/java/com/darass/darass/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.darass.darass.user.service;
 
 import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import com.darass.darass.user.domain.SocialLoginUser;
 import com.darass.darass.user.domain.User;
 import com.darass.darass.user.dto.PasswordCheckRequest;
 import com.darass.darass.user.dto.PasswordCheckResponse;
@@ -8,7 +9,6 @@ import com.darass.darass.user.dto.UserResponse;
 import com.darass.darass.user.dto.UserUpdateRequest;
 import com.darass.darass.user.infrastructure.S3Uploader;
 import com.darass.darass.user.repository.UserRepository;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,8 @@ public class UserService {
 
     public UserResponse update(Long id, UserUpdateRequest userUpdateRequest) {
         Optional<User> expectedUser = userRepository.findById(id);
-        User user = expectedUser.orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_USER::getException);
+        SocialLoginUser user = (SocialLoginUser) expectedUser
+            .orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_USER::getException);
         String nickName = userUpdateRequest.getNickName();
         MultipartFile profileImageFile = userUpdateRequest.getProfileImageFile();
         user.changeNickNameOrProfileImageIfExists(s3Uploader, nickName, profileImageFile);

--- a/backend/src/main/java/com/darass/darass/user/service/UserService.java
+++ b/backend/src/main/java/com/darass/darass/user/service/UserService.java
@@ -30,8 +30,8 @@ public class UserService {
     }
 
     public UserResponse update(Long id, UserUpdateRequest userUpdateRequest) {
-        Optional<User> expectedUser = userRepository.findById(id);
-        SocialLoginUser user = (SocialLoginUser) expectedUser
+        Optional<User> possibleUser = userRepository.findById(id);
+        SocialLoginUser user = (SocialLoginUser) possibleUser
             .orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_USER::getException);
         String nickName = userUpdateRequest.getNickName();
         MultipartFile profileImageFile = userUpdateRequest.getProfileImageFile();
@@ -44,8 +44,8 @@ public class UserService {
     }
 
     public PasswordCheckResponse checkGuestUserPassword(PasswordCheckRequest passwordCheckRequest) {
-        Optional<User> expectedUser = userRepository.findById(passwordCheckRequest.getGuestUserId());
-        User user = expectedUser.orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_USER::getException);
+        Optional<User> possibleUser = userRepository.findById(passwordCheckRequest.getGuestUserId());
+        User user = possibleUser.orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_USER::getException);
 
         if (user.isValidGuestPassword(passwordCheckRequest.getGuestUserPassword())) {
             return new PasswordCheckResponse(true);

--- a/backend/src/test/java/com/darass/darass/DarassApplicationTest.java
+++ b/backend/src/test/java/com/darass/darass/DarassApplicationTest.java
@@ -3,9 +3,10 @@ package com.darass.darass;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @DisplayName("DarassApplication 클래스 ")
 class DarassApplicationTest {
 

--- a/backend/src/test/java/com/darass/darass/auth/oauth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/auth/oauth/service/OAuthServiceTest.java
@@ -2,7 +2,6 @@ package com.darass.darass.auth.oauth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.BDDMockito.given;
 
 import com.darass.darass.SpringContainerTest;
@@ -74,15 +73,6 @@ class OAuthServiceTest extends SpringContainerTest {
         //given
         socialLoginUserRepository.save(socialLoginUser);
 
-        SocialLoginUser updatedSocialLoginUser = SocialLoginUser
-            .builder()
-            .nickName("병욱")
-            .oauthId(socialLoginUser.getOauthId())
-            .oauthProviderType(OAuthProviderType.KAKAO)
-            .email("bbwwpark@naver.com")
-            .profileImageUrl("http://kakao/updated_profile_image.png")
-            .build();
-
         given(oAuthProvider.findSocialLoginUser(any(), any())).willReturn(socialLoginUser);
 
         //then
@@ -91,13 +81,6 @@ class OAuthServiceTest extends SpringContainerTest {
         //when
         String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
         assertThat(payload).isNotNull();
-
-        SocialLoginUser result = socialLoginUserRepository.findById(Long.parseLong(payload)).get();
-        assertThat(result.getNickName()).isNotNull();
-        assertThat(result.getProfileImageUrl()).isNotNull();
-        assertThat(result.getOauthId()).isNotNull();
-        assertThat(result.getOauthProviderType()).isNotNull();
-        assertThat(result.getEmail()).isNotNull();
     }
 
     @DisplayName("findSocialLoginUserByAccessToken 메서드는 accessToken이 주어지면 SocialLoginUser를 리턴한다.")

--- a/backend/src/test/java/com/darass/darass/auth/oauth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/auth/oauth/service/OAuthServiceTest.java
@@ -2,6 +2,7 @@ package com.darass.darass.auth.oauth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.BDDMockito.given;
 
 import com.darass.darass.SpringContainerTest;
@@ -67,7 +68,7 @@ class OAuthServiceTest extends SpringContainerTest {
     }
 
     @Transactional
-    @DisplayName("(로그인 - 이미 DB에 회원정보가 있는경우) login 메서드는 oauth 토큰이 주어지면, 인증서버에서 사용자 정보를 받아와서 DB 업데이트를 하고 primary key를 payload 삼아 accessToken을 리턴한다.")
+    @DisplayName("(로그인 - 이미 DB에 회원정보가 있는경우) login 메서드는 oauth 토큰이 주어지면, primary key를 payload 삼아 accessToken을 리턴한다.")
     @Test
     void oauthLogin_login() {
         //given
@@ -82,20 +83,21 @@ class OAuthServiceTest extends SpringContainerTest {
             .profileImageUrl("http://kakao/updated_profile_image.png")
             .build();
 
-        given(oAuthProvider.findSocialLoginUser(any(), any())).willReturn(updatedSocialLoginUser);
+        given(oAuthProvider.findSocialLoginUser(any(), any())).willReturn(socialLoginUser);
 
         //then
         TokenResponse tokenResponse = oAuthService.oauthLogin(OAuthProviderType.KAKAO.getName(), oauthAccessToken);
 
         //when
         String payload = jwtTokenProvider.getPayload(tokenResponse.getAccessToken());
+        assertThat(payload).isNotNull();
 
         SocialLoginUser result = socialLoginUserRepository.findById(Long.parseLong(payload)).get();
-        assertThat(result.getNickName()).isEqualTo(updatedSocialLoginUser.getNickName());
-        assertThat(result.getProfileImageUrl()).isEqualTo(updatedSocialLoginUser.getProfileImageUrl());
-        assertThat(result.getOauthId()).isEqualTo(updatedSocialLoginUser.getOauthId());
-        assertThat(result.getOauthProviderType()).isEqualTo(updatedSocialLoginUser.getOauthProviderType());
-        assertThat(result.getEmail()).isEqualTo(updatedSocialLoginUser.getEmail());
+        assertThat(result.getNickName()).isNotNull();
+        assertThat(result.getProfileImageUrl()).isNotNull();
+        assertThat(result.getOauthId()).isNotNull();
+        assertThat(result.getOauthProviderType()).isNotNull();
+        assertThat(result.getEmail()).isNotNull();
     }
 
     @DisplayName("findSocialLoginUserByAccessToken 메서드는 accessToken이 주어지면 SocialLoginUser를 리턴한다.")

--- a/backend/src/test/java/com/darass/darass/exception/controller/ControllerAdviceTest.java
+++ b/backend/src/test/java/com/darass/darass/exception/controller/ControllerAdviceTest.java
@@ -1,5 +1,8 @@
 package com.darass.darass.exception.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,6 +14,7 @@ import com.darass.darass.auth.oauth.controller.OAuthController;
 import com.darass.darass.auth.oauth.service.OAuthService;
 import com.darass.darass.comment.controller.CommentController;
 import com.darass.darass.comment.dto.CommentCreateRequest;
+import com.darass.darass.exception.ExceptionWithMessageAndCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,6 +53,21 @@ class ControllerAdviceTest extends SpringContainerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header("Authorization", "")
             .content(new ObjectMapper().writeValueAsString(new CommentCreateRequest())))
+            .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("handleBadRequestException 메서드는 BadRequestException 예외가 발생하면 http 응답코드 400을 반환한다.")
+    @Test
+    void handleBadRequestException() throws Exception {
+        OAuthController oAuthController = mock(OAuthController.class);
+        given(oAuthController.oauthLogin(any(), any())).willThrow(ExceptionWithMessageAndCode.IO_EXCEPTION.getException());
+
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(oAuthController)
+            .setControllerAdvice(new ControllerAdvice())
+            .build();
+
+        mockMvc.perform(get("/api/v1/login/oauth?oauthAccessToken=invalid&oauthProviderName=kakao"))
             .andExpect(status().isBadRequest());
     }
 
@@ -92,5 +111,4 @@ class ControllerAdviceTest extends SpringContainerTest {
         mockMvc.perform(get("/api/v1/login/oauth"))
             .andExpect(status().isInternalServerError());
     }
-
 }

--- a/backend/src/test/java/com/darass/darass/user/controller/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/darass/darass/user/controller/UserAcceptanceTest.java
@@ -12,7 +12,9 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -101,7 +103,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
     public void updateUserNickname_success() throws Exception {
         //given
         String accessToken = tokenProvider.createAccessToken(socialLoginUser.getId().toString());
-        UserUpdateRequest userUpdateRequest = new UserUpdateRequest("병욱");
+        UserUpdateRequest userUpdateRequest = new UserUpdateRequest("병욱", null);
 
         //when
         ResultActions resultActions = 유저_닉네임_수정_요청(userUpdateRequest, accessToken);
@@ -115,7 +117,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
     public void updateUserNickname_fail() throws Exception {
         //given
         String incorrectAccessToken = "incorrectAccessToken";
-        UserUpdateRequest userUpdateRequest = new UserUpdateRequest("병욱");
+        UserUpdateRequest userUpdateRequest = new UserUpdateRequest("병욱", null);
 
         //when
         ResultActions resultActions = 유저_닉네임_수정_요청(userUpdateRequest, incorrectAccessToken);
@@ -285,8 +287,9 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
     private ResultActions 유저_닉네임_수정_요청(UserUpdateRequest userUpdateRequest, String accessToken) throws Exception {
         return this.mockMvc.perform(patch(apiUrl)
-            .contentType(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
             .header("Authorization", "Bearer " + accessToken)
+            .param("nickName", userUpdateRequest.getNickName())
             .content(asJsonString(userUpdateRequest)));
     }
 
@@ -306,8 +309,9 @@ public class UserAcceptanceTest extends AcceptanceTest {
                 requestHeaders(
                     headerWithName("Authorization").description("JWT - Bearer 토큰")
                 ),
-                requestFields(
-                    fieldWithPath("nickName").type(JsonFieldType.STRING).description("새로운 유저 닉네임")
+                requestParts(
+                    partWithName("profileImageFile").description("프로필 이미지 파일").optional(),
+                    partWithName("nickName").description("새로운 유저 닉네임").optional()
                 ),
                 responseFields(
                     fieldWithPath("id").type(JsonFieldType.NUMBER).description("유저 아이디"),

--- a/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
+++ b/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
@@ -2,12 +2,19 @@ package com.darass.darass.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.darass.darass.auth.oauth.api.domain.OAuthProviderType;
 import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import com.darass.darass.user.infrastructure.S3Uploader;
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 @DisplayName("SocialLoginUser 클래스")
 class SocialLoginUserTest {
@@ -49,5 +56,65 @@ class SocialLoginUserTest {
         assertThatThrownBy(() -> {
             assertThat(socialLoginUser.isValidGuestPassword("password")).isTrue();
         }).isEqualTo(ExceptionWithMessageAndCode.NOT_GUEST_USER.getException());
+    }
+
+    @DisplayName("changeNickNameOrProfileImageIfExists 메서드는 nickName만 입력되면, nickName만 변경된다.")
+    @Test
+    void changeNickNameOrProfileImageIfExists_nickName() {
+        // given
+        String initName = "첫이름";
+        String changedName = "변경된이름";
+        String initProfileImageUrl = "첫이미지url주소";
+        SocialLoginUser user = SocialLoginUser.builder()
+            .nickName(initName)
+            .profileImageUrl(initProfileImageUrl)
+            .build();
+
+        // when
+        user.changeNickNameOrProfileImageIfExists(null, changedName, null);
+
+        // then
+        assertThat(user.getNickName()).isEqualTo(changedName);
+        assertThat(user.getProfileImageUrl()).isEqualTo(initProfileImageUrl);
+    }
+
+    @DisplayName("changeNickNameOrProfileImageIfExists 메서드는 profileImageFile만 입력되면, profileImageFile만 변경된다.")
+    @Test
+    void changeNickNameOrProfileImageIfExists_profileImageFile() throws IOException {
+        // given
+        String initName = "첫이름";
+        String initProfileImageUrl = "첫이미지url주소";
+        String changedProfileImageUrl = "변경된이미지url주소";
+        S3Uploader s3Uploader = mock(S3Uploader.class);
+        MultipartFile multipartFile = mock(MultipartFile.class);
+
+        when(s3Uploader.upload(any())).thenReturn(changedProfileImageUrl);
+        SocialLoginUser user = SocialLoginUser.builder()
+            .nickName(initName)
+            .profileImageUrl(initProfileImageUrl)
+            .build();
+
+        // when
+        user.changeNickNameOrProfileImageIfExists(s3Uploader, null, multipartFile);
+
+        // then
+        assertThat(user.getProfileImageUrl()).isEqualTo(changedProfileImageUrl);
+    }
+
+    @DisplayName("changeNickNameOrProfileImageIfExists 메서드는 IOException 예외가 발생할 경우 Internal Server Exception을 발생시킨다.")
+    @Test
+    void changeNickNameOrProfileImageIfExists_throwIOException() throws IOException {
+        // given
+        S3Uploader s3Uploader = mock(S3Uploader.class);
+        when(s3Uploader.upload(any())).thenThrow(new IOException());
+        SocialLoginUser user = SocialLoginUser.builder()
+            .nickName("이름")
+            .profileImageUrl("프로필 이미지")
+            .build();
+        MultipartFile multipartFile = mock(MultipartFile.class);
+
+        // then
+        assertThatThrownBy(() -> user.changeNickNameOrProfileImageIfExists(s3Uploader, null, multipartFile))
+            .isEqualTo(ExceptionWithMessageAndCode.INTERNAL_SERVER.getException());
     }
 }

--- a/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
+++ b/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
@@ -100,21 +100,4 @@ class SocialLoginUserTest {
         // then
         assertThat(user.getProfileImageUrl()).isEqualTo(changedProfileImageUrl);
     }
-
-    @DisplayName("changeNickNameOrProfileImageIfExists 메서드는 IOException 예외가 발생할 경우 Internal Server Exception을 발생시킨다.")
-    @Test
-    void changeNickNameOrProfileImageIfExists_throwIOException() throws IOException {
-        // given
-        S3Uploader s3Uploader = mock(S3Uploader.class);
-        when(s3Uploader.upload(any())).thenThrow(new IOException());
-        SocialLoginUser user = SocialLoginUser.builder()
-            .nickName("이름")
-            .profileImageUrl("프로필 이미지")
-            .build();
-        MultipartFile multipartFile = mock(MultipartFile.class);
-
-        // then
-        assertThatThrownBy(() -> user.changeNickNameOrProfileImageIfExists(s3Uploader, null, multipartFile))
-            .isEqualTo(ExceptionWithMessageAndCode.IO_EXCEPTION.getException());
-    }
 }

--- a/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
+++ b/backend/src/test/java/com/darass/darass/user/domain/SocialLoginUserTest.java
@@ -115,6 +115,6 @@ class SocialLoginUserTest {
 
         // then
         assertThatThrownBy(() -> user.changeNickNameOrProfileImageIfExists(s3Uploader, null, multipartFile))
-            .isEqualTo(ExceptionWithMessageAndCode.INTERNAL_SERVER.getException());
+            .isEqualTo(ExceptionWithMessageAndCode.IO_EXCEPTION.getException());
     }
 }

--- a/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
+++ b/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
@@ -29,7 +29,7 @@ public class S3UploaderTest extends SpringContainerTest {
     @MockBean(name = "s3Client")
     private S3Client s3Client;
 
-    @DisplayName("S3에 이미지를 업로드 했을 때, 정상적으로 이미지 URL을 Return하는 지 테스트")
+    @DisplayName("upload() 메서드는 S3에 이미지를 업로드 했을 때, 정상적으로 이미지 URL을 Return한다.")
     @Test
     public void upload() throws IOException {
         given(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))

--- a/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
+++ b/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
@@ -1,21 +1,23 @@
 package com.darass.darass.user.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.darass.darass.SpringContainerTest;
+import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import com.darass.darass.exception.httpbasicexception.BadRequestException;
+import com.darass.darass.exception.httpbasicexception.InternalServerException;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -40,5 +42,33 @@ public class S3UploaderTest extends SpringContainerTest {
         when(multipartFile.getBytes()).thenReturn(byteArray);
 
         assertThat(s3Uploader.upload(multipartFile)).isNotNull();
+    }
+
+    @DisplayName("upload() 메서드는 IOException이 발생했을 때, BadRequestException 발생시킨다.")
+    @Test
+    public void upload_throwIOException() throws IOException {
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("fileName");
+        when(multipartFile.getBytes()).thenThrow(new IOException());
+
+        assertThatThrownBy(() -> s3Uploader.upload(multipartFile))
+            .isInstanceOf(BadRequestException.class);
+    }
+
+    @DisplayName("upload() 메서드는 SdkClientException이 발생했을 때, InternalServerException을 발생시킨다.")
+    @Test
+    public void upload_throwSdkClientException() throws IOException {
+        // given
+        S3Client s3 = mock(S3Client.class);
+        SdkClientException sdkClientException = mock(SdkClientException.class);
+        when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(sdkClientException);
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("fileName");
+        byte[] byteArray = {};
+        when(multipartFile.getBytes()).thenReturn(byteArray);
+        S3Uploader s3Uploader = new S3Uploader(s3);
+        // when, then
+        assertThatThrownBy(() -> s3Uploader.upload(multipartFile))
+            .isInstanceOf(InternalServerException.class);
     }
 }

--- a/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
+++ b/backend/src/test/java/com/darass/darass/user/infrastructure/S3UploaderTest.java
@@ -1,0 +1,44 @@
+package com.darass.darass.user.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.darass.darass.SpringContainerTest;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@DisplayName("S3Uploader 클래스")
+public class S3UploaderTest extends SpringContainerTest {
+
+    @SpyBean(name = "s3Uploader")
+    private S3Uploader s3Uploader;
+
+    @MockBean(name = "s3Client")
+    private S3Client s3Client;
+
+    @DisplayName("S3에 이미지를 업로드 했을 때, 정상적으로 이미지 URL을 Return하는 지 테스트")
+    @Test
+    public void upload() throws IOException {
+        given(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .willReturn(null);
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        when(multipartFile.getOriginalFilename()).thenReturn("파일이름");
+        byte[] byteArray = {};
+        when(multipartFile.getBytes()).thenReturn(byteArray);
+
+        assertThat(s3Uploader.upload(multipartFile)).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
@@ -98,7 +98,7 @@ class UserServiceTest extends SpringContainerTest {
     @DisplayName("updateNickName 메서드는 유저 id와 UserUpdateRequest가 주어지면, 유저 닉네임을 수정한다.")
     void updateNickName() {
         // when
-        userService.update(user.getId(), new UserUpdateRequest("병욱"));
+        userService.update(user.getId(), new UserUpdateRequest("병욱", null));
 
         // then
         UserResponse userResponse = userService.findById(user.getId());
@@ -110,7 +110,7 @@ class UserServiceTest extends SpringContainerTest {
     void updateNickName_exception() {
         // when then
         Assertions.assertThrows(ExceptionWithMessageAndCode.NOT_FOUND_USER.getException().getClass(),
-            () -> userService.update(0L, new UserUpdateRequest("병욱")));
+            () -> userService.update(0L, new UserUpdateRequest("병욱", null)));
     }
 
     @Test

--- a/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import com.darass.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.darass.project.domain.Project;
 import com.darass.darass.project.repository.ProjectRepository;
 import com.darass.darass.user.domain.GuestUser;
+import com.darass.darass.user.domain.SocialLoginUser;
 import com.darass.darass.user.domain.User;
 import com.darass.darass.user.dto.UserResponse;
 import com.darass.darass.user.dto.UserUpdateRequest;
@@ -44,6 +45,8 @@ class UserServiceTest extends SpringContainerTest {
 
     private User user;
 
+    private SocialLoginUser socialUser;
+
     @BeforeEach
     @Transactional
     void setUp() {
@@ -72,6 +75,13 @@ class UserServiceTest extends SpringContainerTest {
             .comment(comment)
             .build();
         commentLikeRepository.save(commentLike);
+
+        socialUser = SocialLoginUser.builder()
+            .nickName("재성")
+            .build();
+
+        userRepository.save(user);
+        userRepository.save(socialUser);
     }
 
     @Test
@@ -98,10 +108,10 @@ class UserServiceTest extends SpringContainerTest {
     @DisplayName("updateNickName 메서드는 유저 id와 UserUpdateRequest가 주어지면, 유저 닉네임을 수정한다.")
     void updateNickName() {
         // when
-        userService.update(user.getId(), new UserUpdateRequest("병욱", null));
+        userService.update(socialUser.getId(), new UserUpdateRequest("병욱", null));
 
         // then
-        UserResponse userResponse = userService.findById(user.getId());
+        UserResponse userResponse = userService.findById(socialUser.getId());
         assertThat(userResponse.getNickName()).isEqualTo("병욱");
     }
 

--- a/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/user/service/UserServiceTest.java
@@ -98,7 +98,7 @@ class UserServiceTest extends SpringContainerTest {
     @DisplayName("updateNickName 메서드는 유저 id와 UserUpdateRequest가 주어지면, 유저 닉네임을 수정한다.")
     void updateNickName() {
         // when
-        userService.updateNickName(user.getId(), new UserUpdateRequest("병욱"));
+        userService.update(user.getId(), new UserUpdateRequest("병욱"));
 
         // then
         UserResponse userResponse = userService.findById(user.getId());
@@ -110,7 +110,7 @@ class UserServiceTest extends SpringContainerTest {
     void updateNickName_exception() {
         // when then
         Assertions.assertThrows(ExceptionWithMessageAndCode.NOT_FOUND_USER.getException().getClass(),
-            () -> userService.updateNickName(0L, new UserUpdateRequest("병욱")));
+            () -> userService.update(0L, new UserUpdateRequest("병욱")));
     }
 
     @Test


### PR DESCRIPTION
- S3, CloudFront를 바탕으로 한 이미지 업로드 기능 추가
- 유저 정보 변경 시, 닉네임 또는 프로필 사진을 선택적으로 변경할 수 있도록 수정
- 로그인할 때마다 로그인 정보 업데이트 되는 기능 삭제

자코코의 신세계를 오늘 처음 경험해봤네요ㅎ휴ㅠㅠㅠㅠ
그냥 테스트를 막 짤떄보다는 자코코가 퍼센트를 알려주니까
목표를 가지고 테스트를 짤 수 있어서 훨씬 더 재밌었던 것 같네요:)