### PR TITLE
[BE] 댓글 통계 기능 (#354)

### DIFF
--- a/backend/src/docs/asciidoc/api/v1/comments.adoc
+++ b/backend/src/docs/asciidoc/api/v1/comments.adoc
@@ -182,6 +182,44 @@ include::{snippets}/api/v1/projects/comments/search/paging/get/oldest/success/re
 include::{snippets}/api/v1/projects/comments/search/paging/get/oldest/success/http-response.adoc[]
 include::{snippets}/api/v1/projects/comments/search/paging/get/oldest/success/response-fields.adoc[]
 
+=== 특정 프로젝트 내의 댓글에 관한 통계 (GET /api/v1/comments/stat)
+
+==== 특정 프로젝트 내의 댓글 시간별 통계
+
+==== Request
+
+include::{snippets}/api/v1/comments/stat/get/hourly/success/http-request.adoc[]
+include::{snippets}/api/v1/comments/stat/get/hourly/success/request-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/api/v1/comments/stat/get/hourly/success/http-response.adoc[]
+include::{snippets}/api/v1/comments/stat/get/hourly/success/response-fields.adoc[]
+
+==== 특정 프로젝트 내의 댓글 일별 통계
+
+==== Request
+
+include::{snippets}/api/v1/comments/stat/get/daily/success/http-request.adoc[]
+include::{snippets}/api/v1/comments/stat/get/daily/success/request-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/api/v1/comments/stat/get/daily/success/http-response.adoc[]
+include::{snippets}/api/v1/comments/stat/get/daily/success/response-fields.adoc[]
+
+==== 특정 프로젝트 내의 댓글 월별 통계
+
+==== Request
+
+include::{snippets}/api/v1/comments/stat/get/monthly/success/http-request.adoc[]
+include::{snippets}/api/v1/comments/stat/get/monthly/success/request-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/api/v1/comments/stat/get/monthly/success/http-response.adoc[]
+include::{snippets}/api/v1/comments/stat/get/monthly/success/response-fields.adoc[]
+
 === 댓글 수정 (PATCH /api/v1/comments)
 
 ==== (성공) 소셜 로그인 유저 댓글 수정

--- a/backend/src/main/java/com/darass/darass/auth/oauth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/infrastructure/JwtTokenProvider.java
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
-    @Value("${security.jwt.token.secret-key}")
+    @Value("${security.jwt.access-token.secret-key}")
     private String secretKey;
 
-    @Value("${security.jwt.token.expire-length}")
+    @Value("${security.jwt.access-token.expire-length}")
     private long validityInMilliseconds;
 
     public String createAccessToken(String payload) {

--- a/backend/src/main/java/com/darass/darass/auth/oauth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/darass/darass/auth/oauth/infrastructure/JwtTokenProvider.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
+    @Value("${security.jwt.access-token.secret-key}")
     private String secretKeyOfAccessToken;
 
     @Value("${security.jwt.refresh-token.secret-key}")

--- a/backend/src/main/java/com/darass/darass/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/darass/darass/comment/controller/CommentController.java
@@ -10,6 +10,8 @@ import com.darass.darass.comment.dto.CommentReadRequestBySearch;
 import com.darass.darass.comment.dto.CommentReadRequestInProject;
 import com.darass.darass.comment.dto.CommentResponse;
 import com.darass.darass.comment.dto.CommentResponses;
+import com.darass.darass.comment.dto.CommentStatRequest;
+import com.darass.darass.comment.dto.CommentStatResponse;
 import com.darass.darass.comment.dto.CommentUpdateRequest;
 import com.darass.darass.comment.service.CommentService;
 import com.darass.darass.user.domain.User;
@@ -62,6 +64,13 @@ public class CommentController {
         CommentResponses commentResponses = commentService
             .findAllCommentsInProject(commentReadRequestInProject);
         return ResponseEntity.status(HttpStatus.OK).body(commentResponses);
+    }
+
+    // 요청: 옵션(시간별, 일별, 월별), 시작 날짜, 종료 날짜, 프로젝트 키
+    // 응답: {날짜: 카운팅} 리스트
+    @GetMapping("/comments/stat")
+    public ResponseEntity<CommentStatResponse> giveStat(@ModelAttribute CommentStatRequest commentStatRequest) {
+        return ResponseEntity.status(HttpStatus.OK).body(commentService.giveStat(commentStatRequest));
     }
 
     @PostMapping("/comments")

--- a/backend/src/main/java/com/darass/darass/comment/domain/Stat.java
+++ b/backend/src/main/java/com/darass/darass/comment/domain/Stat.java
@@ -1,0 +1,13 @@
+package com.darass.darass.comment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Stat {
+
+    private final String date;
+
+    private final Long count;
+}

--- a/backend/src/main/java/com/darass/darass/comment/dto/CommentStatRequest.java
+++ b/backend/src/main/java/com/darass/darass/comment/dto/CommentStatRequest.java
@@ -1,0 +1,22 @@
+package com.darass.darass.comment.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+@AllArgsConstructor
+public class CommentStatRequest {
+
+    private String periodicity;
+
+    private String projectKey;
+
+    @DateTimeFormat(iso = ISO.DATE)
+    private LocalDate startDate;
+
+    @DateTimeFormat(iso = ISO.DATE)
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/darass/darass/comment/dto/CommentStatResponse.java
+++ b/backend/src/main/java/com/darass/darass/comment/dto/CommentStatResponse.java
@@ -1,0 +1,13 @@
+package com.darass.darass.comment.dto;
+
+import com.darass.darass.comment.domain.Stat;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentStatResponse {
+
+    private List<Stat> stats;
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategy.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategy.java
@@ -1,0 +1,12 @@
+package com.darass.darass.comment.repository;
+
+import com.darass.darass.comment.domain.Stat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CommentCountStrategy {
+
+    boolean isCountable(String period);
+
+    List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate);
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
@@ -1,7 +1,10 @@
 package com.darass.darass.comment.repository;
 
 import com.darass.darass.comment.domain.Stat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -25,8 +28,30 @@ public class CommentCountStrategyByDaily implements CommentCountStrategy {
 
     @Override
     public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
-        return commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
             .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
             .collect(Collectors.toList());
+
+        List<Stat> noneMonthStats = getStatByNoneDaily(startDate, endDate, stats);
+        stats.addAll(noneMonthStats);
+        stats.sort(Comparator.comparing(Stat::getDate));
+        return stats;
+    }
+
+    private List<Stat> getStatByNoneDaily(LocalDateTime startDate, LocalDateTime endDate, List<Stat> stats) {
+        List<Stat> noneMonthStats = new ArrayList<>();
+        LocalDate start = LocalDate.from(startDate);
+        LocalDate end = LocalDate.from(endDate);
+
+        outer:
+        for (LocalDate localDate = start; !localDate.equals(end); localDate = localDate.plusDays(1L)) {
+            for (Stat stat : stats) {
+                if (localDate.toString().equals(stat.getDate())) {
+                    continue outer;
+                }
+            }
+            noneMonthStats.add(new Stat(localDate.toString(), 0L));
+        }
+        return noneMonthStats;
     }
 }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
@@ -1,0 +1,32 @@
+package com.darass.darass.comment.repository;
+
+import com.darass.darass.comment.domain.Stat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCountStrategyByDaily implements CommentCountStrategy {
+
+    private static final String DATE = "DAILY";
+    private static final Integer BEGIN_INDEX = 1;
+    private static final Integer END_INDEX = 10;
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public boolean isCountable(String periodicity) {
+        return DATE.equals(periodicity.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
+        return commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+            .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
+            .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
@@ -17,7 +17,7 @@ public class CommentCountStrategyByDaily implements CommentCountStrategy {
 
     private static final String DATE = "DAILY";
     private static final Integer BEGIN_INDEX = 1;
-    private static final Integer END_INDEX = 10;
+    private static final Integer LENGTH = 10;
 
     private final CommentRepository commentRepository;
 
@@ -28,12 +28,12 @@ public class CommentCountStrategyByDaily implements CommentCountStrategy {
 
     @Override
     public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
-        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, LENGTH).stream()
             .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
             .collect(Collectors.toList());
 
-        List<Stat> noneMonthStats = getStatByNoneDaily(startDate, endDate, stats);
-        stats.addAll(noneMonthStats);
+        List<Stat> noneDailyStats = getStatByNoneDaily(startDate, endDate, stats);
+        stats.addAll(noneDailyStats);
         stats.sort(Comparator.comparing(Stat::getDate));
         return stats;
     }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
@@ -2,6 +2,9 @@ package com.darass.darass.comment.repository;
 
 import com.darass.darass.comment.domain.Stat;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -13,8 +16,8 @@ import org.springframework.stereotype.Component;
 public class CommentCountStrategyByHourly implements CommentCountStrategy {
 
     private static final String DATE = "HOURLY";
-    private static final Integer BEGIN_INDEX = 1;
-    private static final Integer END_INDEX = 13;
+    private static final Integer BEGIN_INDEX = 12;
+    private static final Integer LENGTH = 2;
 
     private final CommentRepository commentRepository;
 
@@ -25,8 +28,29 @@ public class CommentCountStrategyByHourly implements CommentCountStrategy {
 
     @Override
     public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
-        return commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, LENGTH).stream()
             .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
             .collect(Collectors.toList());
+
+        List<Stat> noneHourlyStats = getStatByNoneHourly(startDate, endDate, stats);
+        stats.addAll(noneHourlyStats);
+        stats.sort(Comparator.comparing(Stat::getDate));
+        return stats;
+    }
+
+    private List<Stat> getStatByNoneHourly(LocalDateTime startDate, LocalDateTime endDate, List<Stat> stats) {
+        List<Stat> noneHourlyStats = new ArrayList<>();
+
+        outer:
+        for (LocalTime localTime = LocalTime.MIN; localTime.getHour() != LocalTime.MAX.getHour();
+            localTime = localTime.plusHours(1L)) {
+            for (Stat stat : stats) {
+                if (localTime.toString().equals(stat.getDate())) {
+                    continue outer;
+                }
+            }
+            noneHourlyStats.add(new Stat(String.valueOf(localTime.getHour()), 0L));
+        }
+        return noneHourlyStats;
     }
 }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
@@ -29,12 +29,12 @@ public class CommentCountStrategyByHourly implements CommentCountStrategy {
     @Override
     public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
         List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, LENGTH).stream()
-            .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
+            .map(objects -> new Stat(String.valueOf(Integer.parseInt(String.valueOf(objects[0]))), (Long) objects[1]))
             .collect(Collectors.toList());
 
         List<Stat> noneHourlyStats = getStatByNoneHourly(startDate, endDate, stats);
         stats.addAll(noneHourlyStats);
-        stats.sort(Comparator.comparing(Stat::getDate));
+        stats.sort(Comparator.comparingInt(s -> Integer.parseInt(s.getDate())));
         return stats;
     }
 
@@ -45,7 +45,7 @@ public class CommentCountStrategyByHourly implements CommentCountStrategy {
         for (LocalTime localTime = LocalTime.MIN; localTime.getHour() != LocalTime.MAX.getHour();
             localTime = localTime.plusHours(1L)) {
             for (Stat stat : stats) {
-                if (localTime.toString().equals(stat.getDate())) {
+                if (localTime.getHour() == Integer.parseInt(stat.getDate())) {
                     continue outer;
                 }
             }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
@@ -1,0 +1,32 @@
+package com.darass.darass.comment.repository;
+
+import com.darass.darass.comment.domain.Stat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCountStrategyByHourly implements CommentCountStrategy {
+
+    private static final String DATE = "HOURLY";
+    private static final Integer BEGIN_INDEX = 1;
+    private static final Integer END_INDEX = 13;
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public boolean isCountable(String periodicity) {
+        return DATE.equals(periodicity.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
+        return commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+            .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
+            .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByHourly.java
@@ -42,14 +42,13 @@ public class CommentCountStrategyByHourly implements CommentCountStrategy {
         List<Stat> noneHourlyStats = new ArrayList<>();
 
         outer:
-        for (LocalTime localTime = LocalTime.MIN; localTime.getHour() != LocalTime.MAX.getHour();
-            localTime = localTime.plusHours(1L)) {
+        for (int localTime = LocalTime.MIN.getHour(); localTime <= LocalTime.MAX.getHour(); localTime++) {
             for (Stat stat : stats) {
-                if (localTime.getHour() == Integer.parseInt(stat.getDate())) {
+                if (localTime == Integer.parseInt(stat.getDate())) {
                     continue outer;
                 }
             }
-            noneHourlyStats.add(new Stat(String.valueOf(localTime.getHour()), 0L));
+            noneHourlyStats.add(new Stat(String.valueOf(localTime), 0L));
         }
         return noneHourlyStats;
     }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
@@ -17,7 +17,7 @@ public class CommentCountStrategyByMonthly implements CommentCountStrategy {
 
     private static final String DATE = "MONTHLY";
     private static final Integer BEGIN_INDEX = 1;
-    private static final Integer END_INDEX = 7;
+    private static final Integer LENGTH = 7;
 
     private final CommentRepository commentRepository;
 
@@ -28,7 +28,7 @@ public class CommentCountStrategyByMonthly implements CommentCountStrategy {
 
     @Override
     public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
-        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, LENGTH).stream()
             .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
             .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
@@ -1,0 +1,57 @@
+package com.darass.darass.comment.repository;
+
+import com.darass.darass.comment.domain.Stat;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCountStrategyByMonthly implements CommentCountStrategy {
+
+    private static final String DATE = "MONTHLY";
+    private static final Integer BEGIN_INDEX = 1;
+    private static final Integer END_INDEX = 7;
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public boolean isCountable(String periodicity) {
+        return DATE.equals(periodicity.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public List<Stat> calculateCount(String projectKey, LocalDateTime startDate, LocalDateTime endDate) {
+        List<Stat> stats = commentRepository.findDateCount(projectKey, startDate, endDate, BEGIN_INDEX, END_INDEX).stream()
+            .map(objects -> new Stat((String) objects[0], (Long) objects[1]))
+            .collect(Collectors.toList());
+
+        List<Stat> noneMonthStats = getStatByNoneMonth(startDate, endDate, stats);
+        stats.addAll(noneMonthStats);
+        stats.sort(Comparator.comparing(Stat::getDate));
+        return stats;
+    }
+
+    private List<Stat> getStatByNoneMonth(LocalDateTime startDate, LocalDateTime endDate, List<Stat> stats) {
+        List<Stat> noneMonthStats = new ArrayList<>();
+        YearMonth startYearMonth = YearMonth.from(startDate);
+        YearMonth endYearMonth = YearMonth.from(endDate);
+
+        outer:
+        for (YearMonth yearMonth = startYearMonth; !yearMonth.equals(endYearMonth); yearMonth = yearMonth.plusMonths(1L)) {
+            for (Stat stat : stats) {
+                if (yearMonth.toString().equals(stat.getDate())) {
+                    continue outer;
+                }
+            }
+            noneMonthStats.add(new Stat(yearMonth.toString(), 0L));
+        }
+        return noneMonthStats;
+    }
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyFactory.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyFactory.java
@@ -12,9 +12,9 @@ public class CommentCountStrategyFactory {
 
     private final List<CommentCountStrategy> commentCountStrategies;
 
-    public CommentCountStrategy findStrategy(String period) {
+    public CommentCountStrategy findStrategy(String periodicity) {
         return commentCountStrategies.stream()
-            .filter(strategy -> !Objects.isNull(period) && strategy.isCountable(period))
+            .filter(strategy -> !Objects.isNull(periodicity) && strategy.isCountable(periodicity))
             .findAny()
             .orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_PERIODICITY::getException);
     }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyFactory.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyFactory.java
@@ -1,0 +1,21 @@
+package com.darass.darass.comment.repository;
+
+import com.darass.darass.exception.ExceptionWithMessageAndCode;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCountStrategyFactory {
+
+    private final List<CommentCountStrategy> commentCountStrategies;
+
+    public CommentCountStrategy findStrategy(String period) {
+        return commentCountStrategies.stream()
+            .filter(strategy -> !Objects.isNull(period) && strategy.isCountable(period))
+            .findAny()
+            .orElseThrow(ExceptionWithMessageAndCode.NOT_FOUND_PERIODICITY::getException);
+    }
+}

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
@@ -1,7 +1,6 @@
 package com.darass.darass.comment.repository;
 
 import com.darass.darass.comment.domain.Comment;
-import com.darass.darass.comment.domain.Stat;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
@@ -22,9 +22,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByProjectSecretKeyAndContentContaining(String projectSecretKey, String keyword, Pageable pageable);
 
-    @Query("select substring(c.createdDate, :beginIndex, :endIndex) as date, count(c) as count from Comment c "
+    @Query("select substring(c.createdDate, :beginIndex, :length) as date, count(c) as count from Comment c "
         + "where c.project.secretKey=:projectSecretKey and c.createdDate between :startDate and :endDate group by date")
     List<Object[]> findDateCount(@Param("projectSecretKey") String projectSecretKey,
         @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate,
-        @Param("beginIndex") Integer beginIndex, @Param("endIndex") Integer endIndex);
+        @Param("beginIndex") Integer beginIndex, @Param("length") Integer length);
 }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
@@ -16,6 +16,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByUrlAndProjectSecretKey(String url, String projectSecretKey, Pageable pageable);
 
+    Page<Comment> findByProjectSecretKeyAndCreatedDateBetween(String projectSecretKey, LocalDateTime startDate,
+        LocalDateTime endDate, Pageable pageable);
+
     Page<Comment> findByProjectSecretKeyAndContentContainingAndCreatedDateBetween(String projectSecretKey,
         String keyword, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
   

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentRepository.java
@@ -1,12 +1,15 @@
 package com.darass.darass.comment.repository;
 
 import com.darass.darass.comment.domain.Comment;
+import com.darass.darass.comment.domain.Stat;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
@@ -18,4 +21,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         LocalDateTime endDate, Pageable pageable);
 
     Page<Comment> findByProjectSecretKeyAndContentContaining(String projectSecretKey, String keyword, Pageable pageable);
+
+    @Query("select substring(c.createdDate, :beginIndex, :endIndex) as date, count(c) as count from Comment c "
+        + "where c.project.secretKey=:projectSecretKey and c.createdDate between :startDate and :endDate group by date")
+    List<Object[]> findDateCount(@Param("projectSecretKey") String projectSecretKey,
+        @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate,
+        @Param("beginIndex") Integer beginIndex, @Param("endIndex") Integer endIndex);
 }

--- a/backend/src/main/java/com/darass/darass/comment/service/CommentService.java
+++ b/backend/src/main/java/com/darass/darass/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.darass.darass.comment.service;
 import com.darass.darass.comment.domain.Comment;
 import com.darass.darass.comment.domain.CommentLike;
 import com.darass.darass.comment.domain.SortOption;
+import com.darass.darass.comment.domain.Stat;
 import com.darass.darass.comment.dto.CommentCreateRequest;
 import com.darass.darass.comment.dto.CommentDeleteRequest;
 import com.darass.darass.comment.dto.CommentReadRequest;
@@ -11,7 +12,10 @@ import com.darass.darass.comment.dto.CommentReadRequestBySearch;
 import com.darass.darass.comment.dto.CommentReadRequestInProject;
 import com.darass.darass.comment.dto.CommentResponse;
 import com.darass.darass.comment.dto.CommentResponses;
+import com.darass.darass.comment.dto.CommentStatRequest;
+import com.darass.darass.comment.dto.CommentStatResponse;
 import com.darass.darass.comment.dto.CommentUpdateRequest;
+import com.darass.darass.comment.repository.CommentCountStrategyFactory;
 import com.darass.darass.comment.repository.CommentRepository;
 import com.darass.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.darass.project.domain.Project;
@@ -37,6 +41,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
+    private final CommentCountStrategyFactory commentCountStrategyFactory;
 
     public CommentResponse save(User user, CommentCreateRequest commentRequest) {
         if (!user.isLoginUser()) {
@@ -201,4 +206,12 @@ public class CommentService {
             .user(user)
             .build());
     }
+
+    public CommentStatResponse giveStat(CommentStatRequest request) {
+        List<Stat> stats = commentCountStrategyFactory.findStrategy(request.getPeriodicity())
+            .calculateCount(request.getProjectKey(), request.getStartDate().atTime(LocalTime.MIN),
+                request.getEndDate().atTime(LocalTime.MAX));
+        return new CommentStatResponse(stats);
+    }
+
 }

--- a/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
+++ b/backend/src/main/java/com/darass/darass/exception/ExceptionWithMessageAndCode.java
@@ -36,7 +36,10 @@ public enum ExceptionWithMessageAndCode {
     IO_EXCEPTION(new BadRequestException("업로드할 파일이 잘못되었습니다.", 1000)),
 
     // 페이지네이션 관련 : 11xx
-    PAGE_NOT_POSITIVE_EXCEPTION(new BadRequestException("페이지의 값은 1 이상이어야 합니다.", 1100));
+    PAGE_NOT_POSITIVE_EXCEPTION(new BadRequestException("페이지의 값은 1 이상이어야 합니다.", 1100)),
+
+    // 통계 관련 : 12xx
+    NOT_FOUND_PERIODICITY(new NotFoundException("해당하는 주기가 없습니다.", 1200));
 
     private final CustomException exception;
 

--- a/backend/src/test/java/com/darass/darass/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/acceptance/CommentAcceptanceTest.java
@@ -1,6 +1,5 @@
 package com.darass.darass.comment.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -24,8 +23,6 @@ import com.darass.darass.auth.oauth.api.domain.OAuthProviderType;
 import com.darass.darass.auth.oauth.infrastructure.JwtTokenProvider;
 import com.darass.darass.comment.dto.CommentCreateRequest;
 import com.darass.darass.comment.dto.CommentResponse;
-import com.darass.darass.comment.dto.CommentStatRequest;
-import com.darass.darass.comment.dto.CommentStatResponse;
 import com.darass.darass.comment.dto.CommentUpdateRequest;
 import com.darass.darass.project.domain.Project;
 import com.darass.darass.project.repository.ProjectRepository;
@@ -34,7 +31,6 @@ import com.darass.darass.user.dto.UserResponse;
 import com.darass.darass.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/darass/darass/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/acceptance/CommentAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.darass.darass.comment.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -23,6 +24,8 @@ import com.darass.darass.auth.oauth.api.domain.OAuthProviderType;
 import com.darass.darass.auth.oauth.infrastructure.JwtTokenProvider;
 import com.darass.darass.comment.dto.CommentCreateRequest;
 import com.darass.darass.comment.dto.CommentResponse;
+import com.darass.darass.comment.dto.CommentStatRequest;
+import com.darass.darass.comment.dto.CommentStatResponse;
 import com.darass.darass.comment.dto.CommentUpdateRequest;
 import com.darass.darass.project.domain.Project;
 import com.darass.darass.project.repository.ProjectRepository;
@@ -30,6 +33,8 @@ import com.darass.darass.user.domain.SocialLoginUser;
 import com.darass.darass.user.dto.UserResponse;
 import com.darass.darass.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -850,6 +855,111 @@ public class CommentAcceptanceTest extends AcceptanceTest {
                     fieldWithPath("comments.[].user.nickName").type(JsonFieldType.STRING).description("유저 닉네임"),
                     fieldWithPath("comments.[].user.type").type(JsonFieldType.STRING).description("유저 타입"),
                     fieldWithPath("comments.[].user.profileImageUrl").type(JsonFieldType.STRING).description("유저 프로필 이미지")
+                )
+            ));
+    }
+
+    @DisplayName("특정 프로젝트의 시간별 댓글 통계를 구한다.")
+    @Test
+    void giveStat_hourly() throws Exception {
+        소셜_로그인_댓글_등록됨("content1", "url");
+        소셜_로그인_댓글_등록됨("content2", "url");
+        소셜_로그인_댓글_등록됨("content3", "url");
+        소셜_로그인_댓글_등록됨("content4", "url");
+        소셜_로그인_댓글_등록됨("content5", "url");
+        소셜_로그인_댓글_등록됨("hello6", "url");
+        소셜_로그인_댓글_등록됨("hello7", "url");
+        소셜_로그인_댓글_등록됨("hello8", "url");
+        소셜_로그인_댓글_등록됨("hello9", "url2");
+        소셜_로그인_댓글_등록됨("hello10", "url");
+
+        mockMvc.perform(get("/api/v1/comments/stat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("periodicity", "hourly")
+            .param("projectKey", secretKey)
+            .param("startDate", LocalDate.now().minusYears(1L).toString())
+            .param("endDate", LocalDate.now().toString()))
+            .andExpect(status().isOk())
+            .andDo(document("api/v1/comments/stat/get/hourly/success",
+                requestParameters(
+                    parameterWithName("periodicity").description("주기"),
+                    parameterWithName("projectKey").description("프로젝트 시크릿 키"),
+                    parameterWithName("startDate").description("시작 날짜"),
+                    parameterWithName("endDate").description("종료 날짜")
+                ),
+                responseFields(
+                    fieldWithPath("stats.[].date").type(JsonFieldType.STRING).description("시"),
+                    fieldWithPath("stats.[].count").type(JsonFieldType.NUMBER).description("댓글의 총 개수")
+                )
+            ));
+    }
+
+    @DisplayName("특정 프로젝트의 일별 댓글 통계를 구한다.")
+    @Test
+    void giveStat_daily() throws Exception {
+        소셜_로그인_댓글_등록됨("content1", "url");
+        소셜_로그인_댓글_등록됨("content2", "url");
+        소셜_로그인_댓글_등록됨("content3", "url");
+        소셜_로그인_댓글_등록됨("content4", "url");
+        소셜_로그인_댓글_등록됨("content5", "url");
+        소셜_로그인_댓글_등록됨("hello6", "url");
+        소셜_로그인_댓글_등록됨("hello7", "url");
+        소셜_로그인_댓글_등록됨("hello8", "url");
+        소셜_로그인_댓글_등록됨("hello9", "url2");
+        소셜_로그인_댓글_등록됨("hello10", "url");
+
+        mockMvc.perform(get("/api/v1/comments/stat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("periodicity", "daily")
+            .param("projectKey", secretKey)
+            .param("startDate", LocalDate.now().minusMonths(1L).toString())
+            .param("endDate", LocalDate.now().toString()))
+            .andExpect(status().isOk())
+            .andDo(document("api/v1/comments/stat/get/daily/success",
+                requestParameters(
+                    parameterWithName("periodicity").description("주기"),
+                    parameterWithName("projectKey").description("프로젝트 시크릿 키"),
+                    parameterWithName("startDate").description("시작 날짜"),
+                    parameterWithName("endDate").description("종료 날짜")
+                ),
+                responseFields(
+                    fieldWithPath("stats.[].date").type(JsonFieldType.STRING).description("연월일"),
+                    fieldWithPath("stats.[].count").type(JsonFieldType.NUMBER).description("댓글의 총 개수")
+                )
+            ));
+    }
+
+    @DisplayName("특정 프로젝트의 월별 댓글 통계를 구한다.")
+    @Test
+    void giveStat_monthly() throws Exception {
+        소셜_로그인_댓글_등록됨("content1", "url");
+        소셜_로그인_댓글_등록됨("content2", "url");
+        소셜_로그인_댓글_등록됨("content3", "url");
+        소셜_로그인_댓글_등록됨("content4", "url");
+        소셜_로그인_댓글_등록됨("content5", "url");
+        소셜_로그인_댓글_등록됨("hello6", "url");
+        소셜_로그인_댓글_등록됨("hello7", "url");
+        소셜_로그인_댓글_등록됨("hello8", "url");
+        소셜_로그인_댓글_등록됨("hello9", "url2");
+        소셜_로그인_댓글_등록됨("hello10", "url");
+
+        mockMvc.perform(get("/api/v1/comments/stat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("periodicity", "monthly")
+            .param("projectKey", secretKey)
+            .param("startDate", LocalDate.now().minusYears(1L).toString())
+            .param("endDate", LocalDate.now().toString()))
+            .andExpect(status().isOk())
+            .andDo(document("api/v1/comments/stat/get/monthly/success",
+                requestParameters(
+                    parameterWithName("periodicity").description("주기"),
+                    parameterWithName("projectKey").description("프로젝트 시크릿 키"),
+                    parameterWithName("startDate").description("시작 날짜"),
+                    parameterWithName("endDate").description("종료 날짜")
+                ),
+                responseFields(
+                    fieldWithPath("stats.[].date").type(JsonFieldType.STRING).description("연월"),
+                    fieldWithPath("stats.[].count").type(JsonFieldType.NUMBER).description("댓글의 총 개수")
                 )
             ));
     }

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -290,6 +290,18 @@ class CommentServiceTest extends SpringContainerTest {
             .hasMessage("페이지의 값은 1 이상이어야 합니다.");
     }
 
+    @DisplayName("특정 프로젝트의 시간별 댓글 통계를 구한다.")
+    @Test
+    void stat_hourly() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = LocalDate.of(endDate.getYear(), endDate.getMonthValue() - 1, endDate.getDayOfMonth());
+        CommentStatRequest request = new CommentStatRequest("HOURLY", project.getSecretKey(),
+            startDate, endDate);
+        CommentStatResponse commentStatResponse = commentService.giveStat(request);
+        assertThat(commentStatResponse.getStats())
+            .hasSize(24);
+    }
+
     @DisplayName("특정 프로젝트의 일별 댓글 통계를 구한다.")
     @Test
     void stat_daily() {

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -30,7 +30,6 @@ import com.darass.darass.user.domain.SocialLoginUser;
 import com.darass.darass.user.domain.User;
 import com.darass.darass.user.repository.UserRepository;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -15,6 +15,8 @@ import com.darass.darass.comment.dto.CommentReadRequestByPagination;
 import com.darass.darass.comment.dto.CommentReadRequestBySearch;
 import com.darass.darass.comment.dto.CommentReadRequestInProject;
 import com.darass.darass.comment.dto.CommentResponse;
+import com.darass.darass.comment.dto.CommentStatRequest;
+import com.darass.darass.comment.dto.CommentStatResponse;
 import com.darass.darass.comment.dto.CommentUpdateRequest;
 import com.darass.darass.comment.repository.CommentLikeRepository;
 import com.darass.darass.comment.repository.CommentRepository;
@@ -28,6 +30,7 @@ import com.darass.darass.user.domain.SocialLoginUser;
 import com.darass.darass.user.domain.User;
 import com.darass.darass.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -284,6 +287,18 @@ class CommentServiceTest extends SpringContainerTest {
         assertThatThrownBy(() -> commentService.findAllCommentsInProject(request))
             .isInstanceOf(BadRequestException.class)
             .hasMessage("페이지의 값은 1 이상이어야 합니다.");
+    }
+
+    @DisplayName("특정 프로젝트의 월별 댓글 통계를 구한다.")
+    @Test
+    void stat_monthly() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = LocalDate.of(endDate.getYear(), endDate.getMonthValue() - 4, 1);
+        CommentStatRequest request = new CommentStatRequest("Monthly", project.getSecretKey(),
+            startDate, endDate);
+        CommentStatResponse commentStatResponse = commentService.giveStat(request);
+        assertThat(commentStatResponse.getStats())
+            .hasSize(YearMonth.from(endDate).minusMonths(startDate.getMonthValue()).getMonthValue() + 1);
     }
 
     @DisplayName("소셜 로그인 유저가 댓글을 수정한다.")

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -31,6 +31,7 @@ import com.darass.darass.user.domain.User;
 import com.darass.darass.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -289,16 +290,28 @@ class CommentServiceTest extends SpringContainerTest {
             .hasMessage("페이지의 값은 1 이상이어야 합니다.");
     }
 
+    @DisplayName("특정 프로젝트의 일별 댓글 통계를 구한다.")
+    @Test
+    void stat_daily() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = LocalDate.of(endDate.getYear(), endDate.getMonthValue() - 1, endDate.getDayOfMonth());
+        CommentStatRequest request = new CommentStatRequest("DAILY", project.getSecretKey(),
+            startDate, endDate);
+        CommentStatResponse commentStatResponse = commentService.giveStat(request);
+        assertThat(commentStatResponse.getStats())
+            .hasSize((int) ChronoUnit.DAYS.between(startDate, endDate) + 1);
+    }
+
     @DisplayName("특정 프로젝트의 월별 댓글 통계를 구한다.")
     @Test
     void stat_monthly() {
         LocalDate endDate = LocalDate.now();
         LocalDate startDate = LocalDate.of(endDate.getYear(), endDate.getMonthValue() - 4, 1);
-        CommentStatRequest request = new CommentStatRequest("Monthly", project.getSecretKey(),
+        CommentStatRequest request = new CommentStatRequest("MONTHLY", project.getSecretKey(),
             startDate, endDate);
         CommentStatResponse commentStatResponse = commentService.giveStat(request);
         assertThat(commentStatResponse.getStats())
-            .hasSize(YearMonth.from(endDate).minusMonths(startDate.getMonthValue()).getMonthValue() + 1);
+            .hasSize((int) ChronoUnit.MONTHS.between(startDate, endDate) + 1);
     }
 
     @DisplayName("소셜 로그인 유저가 댓글을 수정한다.")

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -297,8 +297,7 @@ class CommentServiceTest extends SpringContainerTest {
         CommentStatRequest request = new CommentStatRequest("HOURLY", project.getSecretKey(),
             startDate, endDate);
         CommentStatResponse commentStatResponse = commentService.giveStat(request);
-        assertThat(commentStatResponse.getStats())
-            .hasSize(24);
+        assertThat(commentStatResponse.getStats()).hasSize(24);
     }
 
     @DisplayName("특정 프로젝트의 일별 댓글 통계를 구한다.")


### PR DESCRIPTION
프로젝트 내의 댓글을 시간별, 일별, 월별 통계를 내는 기능을 구현했습니다.
주요 구현 사항으로는 Respository 단에서 전략 패턴을 사용하여 분기 처리를 수행하였고, DB 단에서 데이터가 있는 날짜에 대해서 통계 데이터를 가져온 후 애플리케이션 단에서 데이터가 없는 날짜에 관한 통계 데이터를 추가로 넣어주었습니다.
예를 들어, 사용자가 '2021-04'부터 '2021-07'까지 월별 통계를 요구했는데 실제로 데이터가 존재하는 월이 7월뿐이라면, DB단에서는 {'2021-07': 3}과 같은 결과만 반환합니다. 하지만, 통계를 위해서는 0개 짜리 월도 표현해야 합니다. 그래서 애플리케이션 단에서 순회를 돌면서 {'2021-04':0. '2021-05':0. '2021-06':0}과 같은 결과를 추가로 만들어 주었습니다.