### PR TITLE
[BE] 통계 마지막일과 마지막달 0개 처리 긴급 FIX (#449)

### DIFF
--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByDaily.java
@@ -52,10 +52,9 @@ public class CommentCountStrategyByDaily implements CommentCountStrategy {
             }
             noneMonthCommentStats.add(new CommentStat(localDate.toString(), DEFAULT_COMMENT_COUNT));
             localDate = localDate.plusDays(1L);
-
-            if (localDate.equals(end) && !isExistDailyStat(commentStats, localDate)) {
-                noneMonthCommentStats.add(new CommentStat(localDate.toString(), DEFAULT_COMMENT_COUNT));
-            }
+        }
+        if (!isExistDailyStat(commentStats, localDate)) {
+            noneMonthCommentStats.add(new CommentStat(localDate.toString(), DEFAULT_COMMENT_COUNT));
         }
         return noneMonthCommentStats;
     }

--- a/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
+++ b/backend/src/main/java/com/darass/darass/comment/repository/CommentCountStrategyByMonthly.java
@@ -52,12 +52,10 @@ public class CommentCountStrategyByMonthly implements CommentCountStrategy {
             }
             noneMonthCommentStats.add(new CommentStat(yearMonth.toString(), DEFAULT_COMMENT_COUNT));
             yearMonth = yearMonth.plusMonths(1L);
-
-            if (yearMonth.equals(endYearMonth) && !isExistMonthStat(commentStats, yearMonth)) {
-                noneMonthCommentStats.add(new CommentStat(yearMonth.toString(), DEFAULT_COMMENT_COUNT));
-            }
         }
-
+        if (!isExistMonthStat(commentStats, yearMonth)) {
+            noneMonthCommentStats.add(new CommentStat(yearMonth.toString(), DEFAULT_COMMENT_COUNT));
+        }
         return noneMonthCommentStats;
     }
 

--- a/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/darass/comment/service/CommentServiceTest.java
@@ -315,6 +315,17 @@ class CommentServiceTest extends SpringContainerTest {
             .hasSize((int) ChronoUnit.DAYS.between(startDate, endDate) + 1);
     }
 
+    @DisplayName("특정 프로젝트의 일별 댓글 통계를 구한다. (시작 날짜 = 종료 날짜)")
+    @Test
+    void stat_daily_same_date() {
+        LocalDate localDate = LocalDate.now().minusYears(10L);
+        CommentStatRequest request = new CommentStatRequest("DAILY", project.getSecretKey(),
+            localDate, localDate);
+        CommentStatResponse commentStatResponse = commentService.giveStat(request);
+        assertThat(commentStatResponse.getCommentStats())
+            .hasSize(1);
+    }
+
     @DisplayName("특정 프로젝트의 월별 댓글 통계를 구한다.")
     @Test
     void stat_monthly() {
@@ -323,8 +334,17 @@ class CommentServiceTest extends SpringContainerTest {
         CommentStatRequest request = new CommentStatRequest("MONTHLY", project.getSecretKey(),
             startDate, endDate);
         CommentStatResponse commentStatResponse = commentService.giveStat(request);
-        assertThat(commentStatResponse.getCommentStats())
-            .hasSize((int) ChronoUnit.MONTHS.between(startDate, endDate) + 1);
+        assertThat(commentStatResponse.getCommentStats()).hasSize((int) ChronoUnit.MONTHS.between(startDate, endDate) + 1);
+    }
+
+    @DisplayName("특정 프로젝트의 월별 댓글 통계를 구한다. (시작 날짜 = 종료 날짜)")
+    @Test
+    void stat_monthly_same_date() {
+        LocalDate localDate = LocalDate.now().minusYears(10L);
+        CommentStatRequest request = new CommentStatRequest("MONTHLY", project.getSecretKey(),
+            localDate, localDate);
+        CommentStatResponse commentStatResponse = commentService.giveStat(request);
+        assertThat(commentStatResponse.getCommentStats()).hasSize(1);
     }
 
     @DisplayName("소셜 로그인 유저가 댓글을 수정한다.")


### PR DESCRIPTION
현재 while문은 시작 날짜와 종료 날짜가 달라야 수행이 됩니다.
하지만, 시작 날짜와 종료 날짜가 같고 그 날짜에 댓글이 없다면 반복문을 수행하지 않습니다.
따라서 시작 날짜와 종료 날짜가 같을 경우를 판단하는 조건문을 반복문 바깥에 두었습니다.