### PR TITLE
[FE][댓글모듈] 사파리, 파이어폭스 댓글 텍스트 길이 카운팅 이슈 해결 (#522)

### DIFF
--- a/frontend/reply-module/src/__test__/intergration/guestUserComment.test.tsx
+++ b/frontend/reply-module/src/__test__/intergration/guestUserComment.test.tsx
@@ -104,14 +104,14 @@ describe("비로그인 유저 댓글 CRUD 테스트 코드를 작성한다.", ()
         name: /등록/i
       }) as HTMLButtonElement;
 
-      fireEvent.input($commentInputTextArea, { target: { innerText: "댓글 내용" } });
+      fireEvent.input($commentInputTextArea, { target: { textContent: "댓글 내용" } });
       fireEvent.change($guestNickName, { target: { value: "게스트 이름" } });
       fireEvent.change($guestPassword, { target: { value: "게스트 비밀번호" } });
 
       fireEvent.click($submitButton);
 
       await waitFor(() => {
-        expect(($commentInputTextArea as HTMLTextAreaElement).innerText).toBe("");
+        expect(($commentInputTextArea as HTMLTextAreaElement).textContent).toBe("");
         expect(($guestNickName as HTMLInputElement).value).toBe("");
         expect(($guestPassword as HTMLInputElement).value).toBe("");
       });

--- a/frontend/reply-module/src/components/organisms/CommentInput/index.tsx
+++ b/frontend/reply-module/src/components/organisms/CommentInput/index.tsx
@@ -84,7 +84,7 @@ const CommentInput = ({ className, innerRef, user, parentCommentId, onClose }: P
   };
 
   const onInput = (event: ChangeEvent<HTMLDivElement>) => {
-    const currentText = event.target.innerText;
+    const currentText = event.target.textContent || "";
 
     if (currentText.length > MAX_COMMENT_INPUT_LENGTH) {
       postAlertMessage(getErrorMessage.commentInput(currentText));

--- a/frontend/reply-module/src/hooks/useContentEditable.ts
+++ b/frontend/reply-module/src/hooks/useContentEditable.ts
@@ -6,13 +6,13 @@ export const useContentEditable = (initialContent: string) => {
   const [content, _setContent] = useState(initialContent);
 
   const onInput = (event: ChangeEvent<HTMLDivElement>) => {
-    _setContent(event.target.innerText);
+    _setContent(event.target.textContent || "");
     postScrollHeightToParentWindow();
   };
 
   const setContent = (newContent: string) => {
     if ($contentEditable.current) {
-      $contentEditable.current.innerText = newContent;
+      $contentEditable.current.textContent = newContent;
       _setContent(newContent);
     }
   };


### PR DESCRIPTION
`innerText`를 `textContent || ""` 로 변경