### PR TITLE
댓글 관리에서 전체 댓글 개수가 카운팅되지 않는 버그 해결

### DIFF
--- a/backend/src/main/java/com/darass/comment/service/CommentService.java
+++ b/backend/src/main/java/com/darass/comment/service/CommentService.java
@@ -101,7 +101,7 @@ public class CommentService {
                     PageRequest.of(pageBasedIndex, request.getSize(), SortOption.getMatchedSort(request.getSortOption()))
                 );
 
-            return new CommentResponses(new Comments(comments.toList()).totalComment(),
+            return new CommentResponses(comments.getTotalElements(),
                 comments.getTotalPages(), comments.stream()
                 .map(comment -> CommentResponse.of(comment, UserResponse.of(comment.getUser())))
                 .collect(Collectors.toList()));
@@ -123,7 +123,7 @@ public class CommentService {
                     PageRequest.of(pageBasedIndex, request.getSize(), SortOption.getMatchedSort(request.getSortOption()))
                 );
 
-            return new CommentResponses(new Comments(comments.toList()).totalComment(),
+            return new CommentResponses(comments.getTotalElements(),
                 comments.getTotalPages(), comments.stream()
                 .map(comment -> CommentResponse.of(comment, UserResponse.of(comment.getUser())))
                 .collect(Collectors.toList()));


### PR DESCRIPTION
close: #538 
## 문제 상황
![image](https://user-images.githubusercontent.com/56083021/135437223-3d4d727f-bb67-4311-b79a-efc383fb9339.png)

위와 같이 전체 댓글의 개수가 나와야 하는데, 한 페이지에 속한 댓글의 개수가 나오는 이슈가 발생했다.

## 해결 과정
CommentService 객체를 보자.
```java
    public CommentResponses findAllCommentsInProject(
        CommentReadRequestInProject request) {
        int pageBasedIndex = request.getPage() - 1;
        try {
            Page<Comment> comments = commentRepository
                .findByProjectSecretKeyAndCreatedDateBetween(
                    request.getProjectKey(),
                    request.getStartDate().atTime(LocalTime.MIN),
                    request.getEndDate().atTime(LocalTime.MAX),
                    PageRequest.of(pageBasedIndex, request.getSize(), SortOption.getMatchedSort(request.getSortOption()))
                );

            return new CommentResponses(new Comments(comments.toList()).totalComment(),
                comments.getTotalPages(), comments.stream()
                .map(comment -> CommentResponse.of(comment, UserResponse.of(comment.getUser())))
                .collect(Collectors.toList()));
        } catch (IllegalArgumentException e) {
            throw ExceptionWithMessageAndCode.PAGE_NOT_POSITIVE_EXCEPTION.getException();
        }
    }

    public CommentResponses findAllCommentsInProjectUsingSearch(
        CommentReadRequestBySearch request) {
        int pageBasedIndex = request.getPage() - 1;
        try {
            Page<Comment> comments = commentRepository
                .findByProjectSecretKeyAndContentContainingAndCreatedDateBetween(
                    request.getProjectKey(),
                    request.getKeyword(),
                    request.getStartDate().atTime(LocalTime.MIN),
                    request.getEndDate().atTime(LocalTime.MAX),
                    PageRequest.of(pageBasedIndex, request.getSize(), SortOption.getMatchedSort(request.getSortOption()))
                );

            return new CommentResponses(new Comments(comments.toList()).totalComment(),
                comments.getTotalPages(), comments.stream()
                .map(comment -> CommentResponse.of(comment, UserResponse.of(comment.getUser())))
                .collect(Collectors.toList()));
        } catch (IllegalArgumentException e) {
            throw ExceptionWithMessageAndCode.PAGE_NOT_POSITIVE_EXCEPTION.getException();
        }
    }
```
여기서 return 부분을 보면 CommentResponses 객체를 생성하면서 댓글의 전체 개수를 첫 번째 인자로 대입하는 것을 알 수 있다. 이때, `new Comments(comments.toList()).totalComment()` 코드를 사용하는데 해당 메소드는 한 페이지에 속한 댓글의 개수를 반환한다. 왜냐하면 현재 comments는 Page 객체이므로 해당 객체를 이용하여 새로 Comments 객체를 만들고 이 안에서 연산해 봐야 한 페이지의 댓글 개수가 나온다. 그래서 Page 내장 메소드인 `getTotalElements()`를 사용해야 한다.