### PR TITLE
[FE][공통] ContextAPI에서 기본값을 undefined로 주어서 ?.() 문법 사용하던 부분 제거

### DIFF
--- a/frontend/manage/src/components/pages/OAuth/index.tsx
+++ b/frontend/manage/src/components/pages/OAuth/index.tsx
@@ -25,7 +25,7 @@ const OAuth = () => {
           authorizationCode: code
         });
 
-        refetchAccessToken?.();
+        refetchAccessToken();
       } catch (error) {
         console.error(error);
       }

--- a/frontend/manage/src/components/pages/UserProfile/index.tsx
+++ b/frontend/manage/src/components/pages/UserProfile/index.tsx
@@ -68,7 +68,7 @@ const UserProfile = () => {
       await deleteUser();
 
       alert("회원탈퇴에 성공하셨습니다.");
-      logout?.();
+      logout();
     } catch (error) {
       if (error instanceof AlertError) {
         alert(error.message);

--- a/frontend/manage/src/context/userContext.ts
+++ b/frontend/manage/src/context/userContext.ts
@@ -1,28 +1,19 @@
 import { User } from "@/types/user";
 import { createContext, useContext } from "react";
 
-export const UserContext = createContext<{
-  user?: User;
-  logout?: () => void;
-  refetchUser?: () => void;
-  isLoadingUserRequest: boolean;
-  isSuccessUserRequest: boolean;
-  refetchAccessToken?: () => void;
-  accessToken?: string;
-  setUser?: (user?: User) => void;
-  isActiveAccessToken?: boolean;
-  isUserFetched?: boolean;
-}>({
-  user: undefined,
-  logout: undefined,
-  refetchUser: undefined,
-  isLoadingUserRequest: false,
-  isSuccessUserRequest: false,
-  refetchAccessToken: undefined,
-  accessToken: undefined,
-  setUser: undefined,
-  isActiveAccessToken: undefined,
-  isUserFetched: undefined
-});
+export const UserContext = createContext(
+  {} as {
+    user?: User;
+    logout: () => void;
+    refetchUser: () => void;
+    isLoadingUserRequest: boolean;
+    isSuccessUserRequest: boolean;
+    refetchAccessToken: () => void;
+    accessToken?: string;
+    setUser: (user?: User) => void;
+    isActiveAccessToken: boolean;
+    isUserFetched: boolean;
+  }
+);
 
 export const useUserContext = () => useContext(UserContext);

--- a/frontend/manage/src/hooks/api/project/useGetAllProjects.ts
+++ b/frontend/manage/src/hooks/api/project/useGetAllProjects.ts
@@ -49,7 +49,7 @@ export const useGetAllProjects = (enabled = false) => {
 
   useEffect(() => {
     if (error) {
-      logout?.();
+      logout();
     }
   }, [error]);
 

--- a/frontend/manage/src/hooks/api/project/useGetProject.ts
+++ b/frontend/manage/src/hooks/api/project/useGetProject.ts
@@ -57,7 +57,7 @@ export const useGetProject = ({ id }: Props) => {
   }, [user, id]);
 
   useEffect(() => {
-    if (error) logout?.();
+    if (error) logout();
   }, [error]);
 
   return { project, isLoading, error, isSuccess, refetch, isFetched };

--- a/frontend/manage/src/hooks/api/user/useUser.ts
+++ b/frontend/manage/src/hooks/api/user/useUser.ts
@@ -128,7 +128,7 @@ export const useUser = () => {
   };
 
   const logout = () => {
-    removeAccessToken?.();
+    removeAccessToken();
     setUser(undefined);
   };
 

--- a/frontend/reply-module/src/components/@molecules/CommentInput/__test__/CommentInput.test.tsx
+++ b/frontend/reply-module/src/components/@molecules/CommentInput/__test__/CommentInput.test.tsx
@@ -1,6 +1,5 @@
 import { PALETTE } from "@/constants/styles/palette";
 import { useCreateComment, useMessageChannelFromReplyModuleContext } from "@/hooks";
-import { AlertError } from "@/utils/alertError";
 import { getErrorMessage } from "@/utils/errorMessage";
 import { comments } from "@/__test__/fixture/comments";
 import { socialLoginUser } from "@/__test__/fixture/user";
@@ -39,8 +38,7 @@ describe("CommentInput test", () => {
       const props: Props = {
         user: undefined,
         parentCommentId: comments[0].id,
-        isSubComment: false,
-        onClose: () => {}
+        isSubComment: false
       };
 
       const { queryByTestId } = render(<CommentInput {...props} />);
@@ -65,8 +63,7 @@ describe("CommentInput test", () => {
       const props: Props = {
         user: undefined,
         parentCommentId: comments[0].id,
-        isSubComment: false,
-        onClose: () => {}
+        isSubComment: false
       };
 
       const { queryByTestId } = render(<CommentInput {...props} />);

--- a/frontend/reply-module/src/components/@molecules/CommentInput/__test__/CommentInput.test.tsx
+++ b/frontend/reply-module/src/components/@molecules/CommentInput/__test__/CommentInput.test.tsx
@@ -66,7 +66,7 @@ describe("CommentInput test", () => {
         user: undefined,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { queryByTestId } = render(<CommentInput {...props} />);
@@ -79,7 +79,7 @@ describe("CommentInput test", () => {
         user: undefined,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);
@@ -97,7 +97,7 @@ describe("CommentInput test", () => {
         user: undefined,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);
@@ -118,7 +118,7 @@ describe("CommentInput test", () => {
         user: undefined,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);
@@ -140,7 +140,7 @@ describe("CommentInput test", () => {
         user: socialLoginUser,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);
@@ -162,7 +162,7 @@ describe("CommentInput test", () => {
         user: undefined,
         parentCommentId: comments[0].id,
         isSubComment: false,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);
@@ -183,7 +183,7 @@ describe("CommentInput test", () => {
         user: socialLoginUser,
         parentCommentId: undefined,
         isSubComment: true,
-        onClose: undefined
+        onClose: () => {}
       };
 
       const { getByTestId } = render(<CommentInput {...props} />);

--- a/frontend/reply-module/src/components/@molecules/CommentInput/index.tsx
+++ b/frontend/reply-module/src/components/@molecules/CommentInput/index.tsx
@@ -21,7 +21,7 @@ export interface Props {
   user?: User;
   parentCommentId?: Comment["id"];
   isSubComment: boolean;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 const CommentInput = ({ user, parentCommentId, isSubComment, onClose, ...props }: Props) => {
@@ -93,7 +93,7 @@ const CommentInput = ({ user, parentCommentId, isSubComment, onClose, ...props }
     setGuestNickName("");
     setGuestPassword("");
     setIsSecretComment(false);
-    onClose();
+    onClose?.();
     setFormSubmitted(false);
     if (textAreaRef.current) resizeTextArea(textAreaRef.current);
   };

--- a/frontend/reply-module/src/components/@molecules/CommentInput/index.tsx
+++ b/frontend/reply-module/src/components/@molecules/CommentInput/index.tsx
@@ -21,7 +21,7 @@ export interface Props {
   user?: User;
   parentCommentId?: Comment["id"];
   isSubComment: boolean;
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 const CommentInput = ({ user, parentCommentId, isSubComment, onClose, ...props }: Props) => {
@@ -93,7 +93,7 @@ const CommentInput = ({ user, parentCommentId, isSubComment, onClose, ...props }
     setGuestNickName("");
     setGuestPassword("");
     setIsSecretComment(false);
-    onClose?.();
+    onClose();
     setFormSubmitted(false);
     if (textAreaRef.current) resizeTextArea(textAreaRef.current);
   };

--- a/frontend/reply-module/src/components/@molecules/UserAvatarOption/index.tsx
+++ b/frontend/reply-module/src/components/@molecules/UserAvatarOption/index.tsx
@@ -42,7 +42,7 @@ const UserAvatarOption = ({ user, children, ...props }: Props) => {
     formData.append("hasRecentAlarm", "false");
 
     await editUser(formData);
-    await refetchUser?.();
+    await refetchUser();
     setHasNewAlarmOnRealTime?.(false);
 
     openAlarmModal(alarmContents || []);

--- a/frontend/reply-module/src/components/pages/CommentArea/index.tsx
+++ b/frontend/reply-module/src/components/pages/CommentArea/index.tsx
@@ -159,7 +159,7 @@ const CommentArea = ({ isVisible }: Props) => {
           </CommentInputHeader>
         )}
 
-        <CommentInput isSubComment={false} user={user} onClose={() => {}} />
+        <CommentInput isSubComment={false} user={user} />
         <Footer />
       </Container>
     </CommentContext.Provider>

--- a/frontend/reply-module/src/components/pages/CommentArea/index.tsx
+++ b/frontend/reply-module/src/components/pages/CommentArea/index.tsx
@@ -98,7 +98,7 @@ const CommentArea = ({ isVisible }: Props) => {
       if (!popUp || !popUp.closed) return;
 
       clearInterval(timerId);
-      refetchAccessToken?.();
+      refetchAccessToken();
     }, 1000);
   };
 
@@ -159,7 +159,7 @@ const CommentArea = ({ isVisible }: Props) => {
           </CommentInputHeader>
         )}
 
-        <CommentInput isSubComment={false} user={user} />
+        <CommentInput isSubComment={false} user={user} onClose={() => {}} />
         <Footer />
       </Container>
     </CommentContext.Provider>

--- a/frontend/reply-module/src/components/pages/OAuth/index.tsx
+++ b/frontend/reply-module/src/components/pages/OAuth/index.tsx
@@ -24,7 +24,7 @@ const OAuth = () => {
           authorizationCode: code
         });
 
-        refetchAccessToken?.();
+        refetchAccessToken();
       } catch (error) {
         console.error(error);
       }

--- a/frontend/reply-module/src/hooks/api/comment/useCreateComment.ts
+++ b/frontend/reply-module/src/hooks/api/comment/useCreateComment.ts
@@ -12,7 +12,7 @@ export const useCreateComment = () => {
   const { isLoading, isError, error, data, mutation } = useMutation<CreateCommentRequestData, Comment>({
     query: (_data: CreateCommentRequestData) => postCreateComment(_data),
     onSuccess: () => {
-      refetchAllComment?.();
+      refetchAllComment();
     }
   });
 

--- a/frontend/reply-module/src/hooks/api/comment/useDeleteComment.ts
+++ b/frontend/reply-module/src/hooks/api/comment/useDeleteComment.ts
@@ -12,7 +12,7 @@ export const useDeleteComment = () => {
   const { isLoading, isError, error, data, mutation } = useMutation<DeleteCommentRequestParameter, void>({
     query: (_data: DeleteCommentRequestParameter) => _deleteComment(_data),
     onSuccess: () => {
-      refetchAllComment?.();
+      refetchAllComment();
     }
   });
 

--- a/frontend/reply-module/src/hooks/api/comment/useEditComment.ts
+++ b/frontend/reply-module/src/hooks/api/comment/useEditComment.ts
@@ -12,7 +12,7 @@ export const useEditComment = () => {
   const { isLoading, isError, error, data, mutation } = useMutation<EditCommentParameter, void>({
     query: (_data: EditCommentParameter) => _editComment(_data),
     onSuccess: () => {
-      refetchAllComment?.();
+      refetchAllComment();
     }
   });
 

--- a/frontend/reply-module/src/hooks/api/comment/useLikeComment.ts
+++ b/frontend/reply-module/src/hooks/api/comment/useLikeComment.ts
@@ -16,7 +16,7 @@ export const useLikeComment = () => {
   } = useMutation<LikeCommentParameter, void>({
     query: ({ commentId }: LikeCommentParameter) => makeLikeComment(commentId),
     onSuccess: () => {
-      refetchAllComment?.();
+      refetchAllComment();
     }
   });
 

--- a/frontend/reply-module/src/hooks/api/user/useEditUser.ts
+++ b/frontend/reply-module/src/hooks/api/user/useEditUser.ts
@@ -12,7 +12,7 @@ export const useEditUser = () => {
   const { isLoading, error, mutation } = useMutation<FormData, User>({
     query: (data: FormData) => patchEditUser(data),
     onSuccess: () => {
-      refetchUser?.();
+      refetchUser();
     }
   });
 

--- a/frontend/reply-module/src/hooks/api/user/useUser.ts
+++ b/frontend/reply-module/src/hooks/api/user/useUser.ts
@@ -75,7 +75,7 @@ export const useUser = () => {
   };
 
   const logout = () => {
-    removeAccessToken?.();
+    removeAccessToken();
     setUser(undefined);
   };
 

--- a/frontend/reply-module/src/hooks/contexts/useCommentContext.ts
+++ b/frontend/reply-module/src/hooks/contexts/useCommentContext.ts
@@ -1,14 +1,12 @@
 import { Comment } from "@/types";
 import { createContext, useContext } from "react";
 
-export const CommentContext = createContext<{
-  refetchAllComment?: () => void;
-  setComments?: (comments: Comment[]) => void;
-  comments: Comment[];
-}>({
-  refetchAllComment: undefined,
-  setComments: undefined,
-  comments: []
-});
+export const CommentContext = createContext(
+  {} as {
+    refetchAllComment: () => void;
+    setComments: (comments: Comment[]) => void;
+    comments: Comment[];
+  }
+);
 
 export const useCommentContext = () => useContext(CommentContext);

--- a/frontend/reply-module/src/hooks/contexts/useRecentlyAlarmContentContext.ts
+++ b/frontend/reply-module/src/hooks/contexts/useRecentlyAlarmContentContext.ts
@@ -1,14 +1,12 @@
 import { GetAlarmResponse } from "@/types/comment";
 import { createContext, Dispatch, SetStateAction, useContext } from "react";
 
-export const RecentlyAlarmContentContext = createContext<{
-  recentlyAlarmContent: GetAlarmResponse | undefined;
-  hasNewAlarmOnRealTime: boolean | undefined;
-  setHasNewAlarmOnRealTime: Dispatch<SetStateAction<boolean>> | undefined;
-}>({
-  recentlyAlarmContent: undefined,
-  hasNewAlarmOnRealTime: undefined,
-  setHasNewAlarmOnRealTime: undefined
-});
+export const RecentlyAlarmContentContext = createContext(
+  {} as {
+    recentlyAlarmContent: GetAlarmResponse | undefined;
+    hasNewAlarmOnRealTime: boolean | undefined;
+    setHasNewAlarmOnRealTime: Dispatch<SetStateAction<boolean>> | undefined;
+  }
+);
 
 export const useRecentlyAlarmContentContext = () => useContext(RecentlyAlarmContentContext);

--- a/frontend/reply-module/src/hooks/contexts/useUserContext.ts
+++ b/frontend/reply-module/src/hooks/contexts/useUserContext.ts
@@ -1,22 +1,16 @@
 import { User } from "@/types/user";
 import { createContext, useContext } from "react";
 
-export const UserContext = createContext<{
-  user?: User;
-  logout?: () => void;
-  refetchUser?: () => void;
-  isLoadingUserRequest: boolean;
-  isSuccessUserRequest: boolean;
-  refetchAccessToken?: () => void;
-  accessToken?: string;
-}>({
-  user: undefined,
-  logout: undefined,
-  refetchUser: undefined,
-  isLoadingUserRequest: false,
-  isSuccessUserRequest: false,
-  refetchAccessToken: undefined,
-  accessToken: undefined
-});
+export const UserContext = createContext(
+  {} as {
+    user?: User;
+    logout: () => void;
+    refetchUser: () => void;
+    isLoadingUserRequest: boolean;
+    isSuccessUserRequest: boolean;
+    refetchAccessToken: () => void;
+    accessToken?: string;
+  }
+);
 
 export const useUserContext = () => useContext(UserContext);


### PR DESCRIPTION
Context API로 상태관리를 하고 있는데, 내려주는 함수의 초기값으로 `undefined`를 사용하고 있었기 떄문에
사용하는 단에서 무조건 `func?.()` 이렇게 사용해야 했었음.

이제 `createContext({} as MyType)`으로 생성하므로 초기값을 `undefined`로 해줄 필요없음.