### PR TITLE
[FE][배포스크립트] 티스토리 모바일 path 리다이렉트 되도록 수정

### DIFF
--- a/frontend/deploy-script/src/index.ts
+++ b/frontend/deploy-script/src/index.ts
@@ -8,7 +8,16 @@ const messageChannel = {
   replyModal: new MessageChannel()
 };
 
+const blockTistoryMobilePath = () => {
+  if (window.location.host.includes("tistory")) {
+    if (window.location.href.includes("/m/")) {
+      window.location.href = window.location.href.replace("/m/", "/");
+    }
+  }
+};
+
 const init = () => {
+  blockTistoryMobilePath();
   const $darass: HTMLElement | null = document.querySelector("#darass");
 
   if (!$darass) {


### PR DESCRIPTION
- 티스토리 모바일은 /m/ path가 붙고, 다라쓰 스크립트 넣어놓은것이 반영되지 않는다.